### PR TITLE
chore: add next-auth prisma adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "3.3.3",
+        "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "5.17.0",
         "bcryptjs": "2.4.3",
         "next": "14.2.5",
@@ -893,6 +894,16 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@next-auth/prisma-adapter": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@next-auth/prisma-adapter/-/prisma-adapter-1.0.7.tgz",
+      "integrity": "sha512-Cdko4KfcmKjsyHFrWwZ//lfLUbcLqlyFqjd/nYE2m3aZ7tjMNUjpks47iw7NTCnXf+5UWz5Ypyt1dSs1EP5QJw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "@prisma/client": ">=2.26.0 || >=3",
+        "next-auth": "^4"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "3.3.3",
+    "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "5.17.0",
     "bcryptjs": "2.4.3",
     "next": "14.2.5",


### PR DESCRIPTION
## Summary
- add `@next-auth/prisma-adapter` dependency to fix missing module

## Testing
- `npm test` *(fails: failed to resolve "extends":"next/core-web-vitals")*
- `npm run build` *(fails: File 'next/core-web-vitals' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af21a5416083289a70fc87a082c6e6