### PR TITLE
fix: remove invalid tsconfig extension

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "next/core-web-vitals",
   "compilerOptions": {
     "target": "esnext",
     "lib": [


### PR DESCRIPTION
## Summary
- remove incorrect Next.js core web vitals tsconfig extension

## Testing
- `npm test`
- `npm run build` *(fails: Can't resolve '@next-auth/prisma-adapter')*


------
https://chatgpt.com/codex/tasks/task_e_68af25c66b98832884968dd464044fc2