### PR TITLE
Fix prisma seed command configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "db:seed": "npx prisma db seed"
   },
   "prisma": {
-    "seed": "ts-node --compiler-options '{\"module\":\"CommonJS\",\"esModuleInterop\":true}' ./scripts/seed.ts"
+    "seed": "ts-node --project tsconfig.seed.json ./scripts/seed.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "3.3.3",

--- a/tsconfig.seed.json
+++ b/tsconfig.seed.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
## Summary
- avoid JSON quoting issue in Prisma seed by using a dedicated tsconfig file
- add `tsconfig.seed.json` for CommonJS seeding

## Testing
- `npx prisma db seed` *(fails: Can't reach database server at `localhost:5432`)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af3d1b93748328866c00fd6483b365