### PR TITLE
Improve landing page aesthetics with gradients and fonts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,11 +2,62 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { --bg: #0b0b0c; --fg: #f5f5f5; }
-html, body { background: var(--bg); color: var(--fg); }
-a { text-decoration: underline; }
-input, select, button { color: black; }
-table { width: 100%; border-collapse: collapse; }
-th, td { border-bottom: 1px solid #333; padding: 8px; text-align: left; }
-.container { max-width: 1000px; margin: 0 auto; padding: 24px; }
-.btn { background: white; color: black; padding: 8px 12px; border-radius: 6px; display: inline-block; }
+html {
+  font-family: var(--font-sans);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-display);
+}
+
+a {
+  color: #5b21b6;
+  text-decoration: underline;
+}
+
+a:hover {
+  color: #4338ca;
+}
+
+input,
+select,
+button {
+  color: black;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border-bottom: 1px solid #333;
+  padding: 8px;
+  text-align: left;
+}
+
+.container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.btn {
+  background: linear-gradient(135deg, #7f5af0, #9d4edd);
+  color: white;
+  padding: 12px 24px;
+  border-radius: 9999px;
+  display: inline-block;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,16 @@
 import './globals.css';
 import type { ReactNode } from 'react';
+import { Playfair_Display, Open_Sans } from 'next/font/google';
+
+const playfair = Playfair_Display({
+  subsets: ['latin'],
+  variable: '--font-display'
+});
+
+const openSans = Open_Sans({
+  subsets: ['latin'],
+  variable: '--font-sans'
+});
 
 export const metadata = {
   title: 'Servicios SaaS',
@@ -8,8 +19,10 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="es">
-      <body className="min-h-screen antialiased">{children}</body>
+    <html lang="es" className={`${openSans.variable} ${playfair.variable}`}>
+      <body className="min-h-screen antialiased bg-gradient-to-br from-[#faaca8] to-[#dad0ec] text-gray-800">
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,13 +2,17 @@ import Link from 'next/link';
 
 export default function Home() {
   return (
-    <div className="container">
-      <h1 className="text-3xl font-bold mb-4">Servicios SaaS</h1>
-      <p className="mb-4">Landing simple. Mirá nuestros servicios y precios.</p>
-      <div className="flex gap-3">
-        <Link className="btn" href="/servicios">Ver servicios</Link>
-        <Link className="btn" href="/admin">Entrar al Admin</Link>
+    <main className="flex min-h-screen flex-col items-center justify-center px-4 text-center">
+      <h1 className="mb-6 text-5xl font-bold">Servicios SaaS</h1>
+      <p className="mb-8 max-w-xl">Landing simple. Mirá nuestros servicios y precios.</p>
+      <div className="flex flex-wrap justify-center gap-4">
+        <Link className="btn" href="/servicios">
+          Ver servicios
+        </Link>
+        <Link className="btn" href="/admin">
+          Entrar al Admin
+        </Link>
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- load Playfair Display and Open Sans fonts
- add gradient background and accent styles
- center landing content with updated buttons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af4018e68c8328bc031099b2d3db6a