### PR TITLE
Fix admin session and seed extra admin user

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -4,10 +4,27 @@ import { PrismaAdapter } from '@next-auth/prisma-adapter';
 import { prisma } from '@/lib/db';
 import { compare } from 'bcryptjs';
 import { z } from 'zod';
+import { Role } from '@prisma/client';
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   session: { strategy: 'jwt' },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.id = (user as any).id;
+        token.role = (user as any).role;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        (session.user as any).id = token.id as string;
+        (session.user as any).role = token.role as Role;
+      }
+      return session;
+    }
+  },
   providers: [
     Credentials({
       credentials: {

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,22 @@
+import { DefaultSession } from 'next-auth';
+import { Role } from '@prisma/client';
+
+declare module 'next-auth' {
+  interface Session {
+    user: {
+      id: string;
+      role: Role;
+    } & DefaultSession['user'];
+  }
+
+  interface User {
+    role: Role;
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    id?: string;
+    role?: Role;
+  }
+}

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -26,6 +26,17 @@ async function main() {
     }
   });
 
+  const subsPasswordHash = await bcrypt.hash('Suscripciones8778!', 10);
+  await prisma.user.upsert({
+    where: { email: 'subscripcion.info@gmail.com' },
+    update: {},
+    create: {
+      email: 'subscripcion.info@gmail.com',
+      passwordHash: subsPasswordHash,
+      role: Role.ADMIN
+    }
+  });
+
   // Example services
   const services = await Promise.all([
     prisma.service.upsert({


### PR DESCRIPTION
## Summary
- include role/id in JWT and session callbacks for admin panel access
- seed additional admin user subscripcion.info@gmail.com
- add NextAuth type declarations for role

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68af692b990c8328a82d411d7e4bba3d