### PR TITLE
feat: admin can edit service prices and images

### DIFF
--- a/app/admin/precios/[serviceId]/page.tsx
+++ b/app/admin/precios/[serviceId]/page.tsx
@@ -33,7 +33,7 @@ export default async function CambiarPrecio({ params }: { params: { serviceId: s
   }
 
   return (
-    <form action={change} className="max-w-sm space-y-3">
+    <form action={change} className="max-w-sm space-y-3 bg-white p-4 text-black">
       <h1 className="text-xl font-bold">Cambiar precio - {s.name}</h1>
       <p>Actual: {current ? `${current.currency} ${(current.amountCents/100).toFixed(2)}` : 'No definido'}</p>
       <input className="border p-2 w-full" name="currency" defaultValue={current?.currency || 'USD'} />

--- a/app/admin/precios/page.tsx
+++ b/app/admin/precios/page.tsx
@@ -9,7 +9,7 @@ export default async function Precios() {
   });
 
   return (
-    <div>
+    <div className="bg-white p-4 text-black">
       <h1 className="text-2xl font-bold mb-4">Precios</h1>
       {servicios.map(s => {
         const current = s.prices.find(p => p.isCurrent);
@@ -17,19 +17,10 @@ export default async function Precios() {
           <div key={s.id} className="mb-8">
             <h2 className="text-xl font-semibold">{s.name}</h2>
             <p className="mb-2">Precio vigente: {current ? `${current.currency} ${(current.amountCents/100).toFixed(2)}` : 'No definido'}</p>
-            <form action={async (formData: FormData) => {
-              'use server';
-              const currency = String(formData.get('currency') || 'USD');
-              const amount = Number(formData.get('amount'));
-              const now = new Date();
-              const curr = await prisma.price.findFirst({ where: { serviceId: s.id, isCurrent: true } as any });
-            }}>
-              {/* Left intentionally blank to avoid TS/Prisma server action complexity here */}
-            </form>
+            <a className="text-blue-600 underline" href={`/admin/precios/${s.id}`}>Cambiar precio</a>
           </div>
         );
       })}
-      <p className="mt-6 text-sm opacity-80">Para cambiar precio, entra al detalle del servicio.</p>
     </div>
   );
 }

--- a/app/admin/servicios/[id]/page.tsx
+++ b/app/admin/servicios/[id]/page.tsx
@@ -2,24 +2,57 @@ import { prisma } from '@/lib/db';
 import { notFound, redirect } from 'next/navigation';
 
 export default async function EditServicio({ params }: { params: { id: string } }) {
-  const s = await prisma.service.findUnique({ where: { id: params.id } });
+  const s = await prisma.service.findUnique({ where: { id: params.id }, include: { prices: { where: { isCurrent: true } } } });
   if (!s) return notFound();
+  const current = s.prices[0];
   const serviceId = s.id;
 
   async function update(formData: FormData) {
     'use server';
     const name = String(formData.get('name') || '');
     const description = String(formData.get('description') || '');
+    const imageUrl = String(formData.get('imageUrl') || '');
     const isActive = formData.get('isActive') === 'on';
-    await prisma.service.update({ where: { id: serviceId }, data: { name, description, isActive } });
+    const currency = String(formData.get('currency') || 'USD');
+    const amount = Number(formData.get('amount') || 0);
+    await prisma.service.update({ where: { id: serviceId }, data: { name, description, imageUrl, isActive } });
+    const now = new Date();
+    const prev = await prisma.price.findFirst({ where: { serviceId, isCurrent: true } });
+    if (amount > 0 && (prev?.amountCents !== Math.round(amount * 100) || prev?.currency !== currency)) {
+      if (prev) {
+        await prisma.price.update({ where: { id: prev.id }, data: { isCurrent: false, activeTo: now } });
+      }
+      await prisma.price.create({
+        data: {
+          serviceId,
+          currency,
+          amountCents: Math.round(amount * 100),
+          activeFrom: now,
+          isCurrent: true
+        }
+      });
+      await prisma.auditLog.create({
+        data: {
+          action: 'CHANGE_PRICE',
+          entity: 'Service',
+          entityId: serviceId,
+          diff: { from: prev?.amountCents ?? null, to: Math.round(amount * 100) } as any
+        }
+      });
+    }
     redirect('/admin/servicios');
   }
 
   return (
-    <form action={update} className="max-w-lg space-y-3">
+    <form action={update} className="max-w-lg space-y-3 bg-white p-4 text-black">
       <h1 className="text-xl font-bold">Editar servicio</h1>
       <input className="border p-2 w-full" name="name" defaultValue={s.name} />
       <textarea className="border p-2 w-full" name="description" defaultValue={s.description || ''} />
+      <input className="border p-2 w-full" name="imageUrl" defaultValue={s.imageUrl || ''} placeholder="URL de la imagen" />
+      <div className="flex gap-2">
+        <input className="border p-2 w-full" name="currency" defaultValue={current?.currency || 'USD'} />
+        <input className="border p-2 w-full" name="amount" type="number" step="0.01" defaultValue={current ? (current.amountCents / 100).toString() : ''} />
+      </div>
       <label className="flex items-center gap-2"><input type="checkbox" name="isActive" defaultChecked={s.isActive} /> Activo</label>
       <button className="btn" type="submit">Guardar</button>
     </form>

--- a/app/admin/servicios/nuevo/page.tsx
+++ b/app/admin/servicios/nuevo/page.tsx
@@ -7,17 +7,45 @@ export default function NuevoServicio() {
     const name = String(formData.get('name') || '');
     const slug = String(formData.get('slug') || '');
     const description = String(formData.get('description') || '');
+    const imageUrl = String(formData.get('imageUrl') || '');
+    const currency = String(formData.get('currency') || 'USD');
+    const amount = Number(formData.get('amount') || 0);
     if (!name || !slug) return;
-    await prisma.service.create({ data: { name, slug, description } });
+    const service = await prisma.service.create({ data: { name, slug, description, imageUrl } });
+    if (amount > 0) {
+      const now = new Date();
+      await prisma.price.create({
+        data: {
+          serviceId: service.id,
+          currency,
+          amountCents: Math.round(amount * 100),
+          activeFrom: now,
+          isCurrent: true
+        }
+      });
+      await prisma.auditLog.create({
+        data: {
+          action: 'CHANGE_PRICE',
+          entity: 'Service',
+          entityId: service.id,
+          diff: { from: null, to: Math.round(amount * 100) } as any
+        }
+      });
+    }
     redirect('/admin/servicios');
   }
 
   return (
-    <form action={create} className="max-w-lg space-y-3">
+    <form action={create} className="max-w-lg space-y-3 bg-white p-4 text-black">
       <h1 className="text-xl font-bold">Nuevo servicio</h1>
       <input className="border p-2 w-full" name="name" placeholder="Nombre" />
       <input className="border p-2 w-full" name="slug" placeholder="slug-unico" />
       <textarea className="border p-2 w-full" name="description" placeholder="Descripción" />
+      <input className="border p-2 w-full" name="imageUrl" placeholder="URL de la imagen" />
+      <div className="flex gap-2">
+        <input className="border p-2 w-full" name="currency" defaultValue="USD" />
+        <input className="border p-2 w-full" name="amount" type="number" step="0.01" placeholder="Precio" />
+      </div>
       <button className="btn" type="submit">Crear</button>
     </form>
   );

--- a/app/admin/servicios/page.tsx
+++ b/app/admin/servicios/page.tsx
@@ -6,7 +6,7 @@ export const revalidate = 0;
 export default async function AdminServicios() {
   const servicios = await prisma.service.findMany({ orderBy: { createdAt: 'desc' } });
   return (
-    <div>
+    <div className="bg-white p-4 text-black">
       <h1 className="text-2xl font-bold mb-4">Servicios</h1>
       <Link className="btn" href="/admin/servicios/nuevo">Nuevo servicio</Link>
       <table className="mt-4">

--- a/components/landing/Testimonials.tsx
+++ b/components/landing/Testimonials.tsx
@@ -14,7 +14,7 @@ export function Testimonials() {
         {testimonials.map(t => (
           <Card key={t.author} className="bg-white/5">
             <CardContent className="p-6">
-              <p className="mb-4 italic">"{t.quote}"</p>
+              <p className="mb-4 italic">&ldquo;{t.quote}&rdquo;</p>
               <p className="text-sm font-semibold">{t.author}</p>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
- allow admins to set image and initial price when creating services
- enable editing service price, image, and visibility from edit page
- improve admin page readability and add link to price editor; fix testimonial quotes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af735dd7dc832886a27311862d531b