### PR TITLE
Increase card contrast for better visibility

### DIFF
--- a/components/landing/Pricing.tsx
+++ b/components/landing/Pricing.tsx
@@ -13,7 +13,7 @@ export function Pricing() {
       <h2 className="mb-8 text-center text-3xl font-bold">Precios</h2>
       <div className="grid gap-8 md:grid-cols-3">
         {plans.map(p => (
-          <Card key={p.name} className="bg-white/5 text-center">
+          <Card key={p.name} className="text-center">
             <CardHeader>
               <CardTitle>{p.name}</CardTitle>
             </CardHeader>

--- a/components/landing/Projects.tsx
+++ b/components/landing/Projects.tsx
@@ -13,7 +13,7 @@ export function Projects() {
       <h2 className="mb-8 text-center text-3xl font-bold">Proyectos</h2>
       <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
         {projects.map(p => (
-          <Card key={p.title} className="overflow-hidden bg-white/5">
+          <Card key={p.title} className="overflow-hidden">
             <Image src={p.image} alt={p.title} width={600} height={400} className="h-40 w-full object-cover" />
             <CardContent className="p-4">
               <p>{p.title}</p>

--- a/components/landing/Services.tsx
+++ b/components/landing/Services.tsx
@@ -20,7 +20,7 @@ export async function Services() {
         {servicios.map((s, i) => {
           const Icon = icons[i % icons.length];
           return (
-            <Card key={s.id} className="bg-white/5">
+            <Card key={s.id}>
               <CardHeader className="flex items-center gap-2">
                 <Icon className="h-6 w-6 text-blue-500" aria-hidden />
                 <CardTitle>{s.name}</CardTitle>

--- a/components/landing/Stats.tsx
+++ b/components/landing/Stats.tsx
@@ -19,7 +19,7 @@ export function Stats() {
     <section className="container py-16">
       <div className="grid gap-8 md:grid-cols-3">
         {stats.map(s => (
-          <Card key={s.label} className="bg-white/5 text-center">
+          <Card key={s.label} className="text-center">
             <CardContent className="p-6 flex flex-col items-center">
               <s.icon className="mb-2 h-8 w-8 text-blue-500" aria-hidden />
               <p className="text-4xl font-bold">{s.value}</p>

--- a/components/landing/Testimonials.tsx
+++ b/components/landing/Testimonials.tsx
@@ -12,7 +12,7 @@ export function Testimonials() {
       <h2 className="mb-8 text-center text-3xl font-bold">Testimonios</h2>
       <div className="grid gap-8 md:grid-cols-3">
         {testimonials.map(t => (
-          <Card key={t.author} className="bg-white/5">
+          <Card key={t.author}>
             <CardContent className="p-6">
               <p className="mb-4 italic">&ldquo;{t.quote}&rdquo;</p>
               <p className="text-sm font-semibold">{t.author}</p>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/lib/utils';
 
 export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('rounded-lg border bg-white/5 p-6 shadow-sm', className)} {...props} />
+    <div ref={ref} className={cn('rounded-lg border bg-white/10 p-6 shadow-sm', className)} {...props} />
   )
 );
 Card.displayName = 'Card';


### PR DESCRIPTION
## Summary
- use a lighter card background for improved contrast
- rely on the new default card style across landing sections

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af9708dd608328b19d10c7e0d5a212