### PR TITLE
Improve responsive layout and button styles

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -13,14 +13,14 @@ export function Hero() {
         className="px-4"
       >
         <h1 className="mb-4 font-serif text-5xl md:text-7xl">Servicios SaaS</h1>
-        <p className="mb-8 text-lg text-zinc-600 md:text-2xl">
+        <p className="mb-8 mx-auto max-w-prose text-lg text-zinc-700 md:text-2xl">
           Lanza y vende tus servicios digitales con pagos cripto o tarjeta.
         </p>
-        <div className="flex justify-center gap-4">
-          <Button asChild>
+        <div className="flex flex-col items-stretch gap-4 sm:flex-row sm:justify-center">
+          <Button asChild className="w-full sm:w-auto">
             <a href="#servicios">Ver servicios</a>
           </Button>
-          <Button asChild variant="outline">
+          <Button asChild variant="outline" className="w-full sm:w-auto">
             <a href="#contacto">Contactar</a>
           </Button>
         </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
+import { cn } from '@/lib/utils';
 
 const links = [
   { href: '#servicios', label: 'Servicios' },
@@ -20,10 +21,20 @@ export function Navbar() {
         <button className="sm:hidden" onClick={() => setOpen(!open)} aria-label="Toggle menu">
           ☰
         </button>
-        <ul className={`sm:flex gap-6 text-sm ${open ? 'block' : 'hidden'} sm:block`}>
+        <ul
+          className={cn(
+            'text-sm',
+            open
+              ? 'absolute left-0 right-0 top-full flex flex-col items-center gap-4 bg-white p-4 shadow-md'
+              : 'hidden',
+            'sm:static sm:flex sm:flex-row sm:gap-6 sm:bg-transparent sm:p-0'
+          )}
+        >
           {links.map(l => (
             <li key={l.href}>
-              <a href={l.href} className="hover:underline" onClick={() => setOpen(false)}>{l.label}</a>
+              <a href={l.href} className="hover:underline" onClick={() => setOpen(false)}>
+                {l.label}
+              </a>
             </li>
           ))}
           <li>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,10 +4,27 @@ import { cn } from '@/lib/utils';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: boolean;
+  variant?: 'default' | 'outline';
 }
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, asChild, ...props }, ref) => {
-  const Comp = asChild ? Slot : 'button';
-  return <Comp ref={ref} className={cn('px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700', className)} {...props} />;
-});
+const baseClasses =
+  'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+
+const variants: Record<NonNullable<ButtonProps['variant']>, string> = {
+  default: 'bg-blue-600 text-white hover:bg-blue-700',
+  outline: 'border border-blue-600 text-blue-600 hover:bg-blue-50'
+};
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, asChild = false, variant = 'default', ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        ref={ref}
+        className={cn(baseClasses, variants[variant], className)}
+        {...props}
+      />
+    );
+  }
+);
 Button.displayName = 'Button';


### PR DESCRIPTION
## Summary
- add variant support and accessible styling to Button component
- stack hero section buttons on small screens for better readability
- refine mobile navbar to prevent overlapping links

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afb9860df08328be5d3565989aa4dc