### PR TITLE
fix: render admin tables via client components

### DIFF
--- a/app/admin/precios/PreciosTable.tsx
+++ b/app/admin/precios/PreciosTable.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { ColumnDef } from '@tanstack/react-table';
+import { DataTable } from '@/components/admin/DataTable';
+import { formatMoney } from '@/lib/format';
+import type { Price, Service } from '@prisma/client';
+
+export type PriceWithService = Price & { service: Service };
+
+const columns: ColumnDef<PriceWithService>[] = [
+  {
+    accessorKey: 'service.name',
+    header: 'Servicio',
+    cell: ({ row }) => row.original.service.name,
+  },
+  {
+    accessorKey: 'amountCents',
+    header: 'Monto',
+    cell: ({ row }) => formatMoney(row.original.amountCents, row.original.currency),
+  },
+  { accessorKey: 'currency', header: 'Moneda' },
+  {
+    accessorKey: 'isCurrent',
+    header: 'Actual',
+    cell: ({ getValue }) => (getValue<boolean>() ? 'Sí' : 'No'),
+  },
+];
+
+export function PreciosTable({ data }: { data: PriceWithService[] }) {
+  return <DataTable columns={columns} data={data} />;
+}
+

--- a/app/admin/precios/page.tsx
+++ b/app/admin/precios/page.tsx
@@ -1,38 +1,16 @@
 import { prisma } from '@/lib/db';
-import { ColumnDef } from '@tanstack/react-table';
 import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
-import { DataTable } from '@/components/admin/DataTable';
-import { formatMoney } from '@/lib/format';
+import { PreciosTable } from './PreciosTable';
 
 export const revalidate = 0;
 
 export default async function PreciosPage() {
   const prices = await prisma.price.findMany({ include: { service: true } });
-  type Price = typeof prices[number];
-
-  const columns: ColumnDef<Price>[] = [
-    {
-      accessorKey: 'service.name',
-      header: 'Servicio',
-      cell: ({ row }) => row.original.service.name
-    },
-    {
-      accessorKey: 'amountCents',
-      header: 'Monto',
-      cell: ({ row }) => formatMoney(row.original.amountCents, row.original.currency)
-    },
-    { accessorKey: 'currency', header: 'Moneda' },
-    {
-      accessorKey: 'isCurrent',
-      header: 'Actual',
-      cell: ({ getValue }) => (getValue<boolean>() ? 'Sí' : 'No')
-    }
-  ];
 
   return (
     <div>
       <Breadcrumbs items={[{ label: 'Dashboard', href: '/admin' }, { label: 'Precios' }]} />
-      <DataTable columns={columns} data={prices} />
+      <PreciosTable data={prices} />
     </div>
   );
 }

--- a/app/admin/servicios/ServiciosTable.tsx
+++ b/app/admin/servicios/ServiciosTable.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { ColumnDef } from '@tanstack/react-table';
+import { DataTable } from '@/components/admin/DataTable';
+import { StatusBadge } from '@/components/admin/StatusBadge';
+import Link from 'next/link';
+import type { Service, Price } from '@prisma/client';
+
+export type ServiceWithPrices = Service & { prices: Price[] };
+
+const columns: ColumnDef<ServiceWithPrices>[] = [
+  { accessorKey: 'name', header: 'Nombre' },
+  {
+    accessorKey: 'isActive',
+    header: 'Estado',
+    cell: ({ getValue }) => <StatusBadge active={getValue<boolean>()} />,
+  },
+  {
+    id: 'prices',
+    header: 'Precios',
+    cell: ({ row }) => row.original.prices.length,
+  },
+  {
+    accessorKey: 'updatedAt',
+    header: 'Actualizado',
+    cell: ({ getValue }) => new Date(getValue<string>()).toLocaleDateString(),
+  },
+  {
+    id: 'actions',
+    header: 'Acciones',
+    cell: ({ row }) => (
+      <Link className="text-blue-600 underline" href={`/admin/servicios/${row.original.id}`}>
+        Editar
+      </Link>
+    ),
+  },
+];
+
+export function ServiciosTable({ data }: { data: ServiceWithPrices[] }) {
+  return <DataTable columns={columns} data={data} />;
+}
+

--- a/app/admin/servicios/page.tsx
+++ b/app/admin/servicios/page.tsx
@@ -1,9 +1,6 @@
 import { prisma } from '@/lib/db';
-import { ColumnDef } from '@tanstack/react-table';
-import Link from 'next/link';
 import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
-import { DataTable } from '@/components/admin/DataTable';
-import { StatusBadge } from '@/components/admin/StatusBadge';
+import { ServiciosTable } from './ServiciosTable';
 
 export const revalidate = 0;
 
@@ -13,40 +10,10 @@ export default async function ServiciosPage() {
     orderBy: { updatedAt: 'desc' }
   });
 
-  type Service = typeof services[number];
-
-  const columns: ColumnDef<Service>[] = [
-    { accessorKey: 'name', header: 'Nombre' },
-    {
-      accessorKey: 'isActive',
-      header: 'Estado',
-      cell: ({ getValue }) => <StatusBadge active={getValue<boolean>()} />
-    },
-    {
-      id: 'prices',
-      header: 'Precios',
-      cell: ({ row }) => row.original.prices.length
-    },
-    {
-      accessorKey: 'updatedAt',
-      header: 'Actualizado',
-      cell: ({ getValue }) => new Date(getValue<string>()).toLocaleDateString()
-    },
-    {
-      id: 'actions',
-      header: 'Acciones',
-      cell: ({ row }) => (
-        <Link className="text-blue-600 underline" href={`/admin/servicios/${row.original.id}`}>
-          Editar
-        </Link>
-      )
-    }
-  ];
-
   return (
     <div>
       <Breadcrumbs items={[{ label: 'Dashboard', href: '/admin' }, { label: 'Servicios' }]} />
-      <DataTable columns={columns} data={services} />
+      <ServiciosTable data={services} />
     </div>
   );
 }

--- a/components/admin/StatusBadge.tsx
+++ b/components/admin/StatusBadge.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { cn } from "@/lib/utils";
 
 export function StatusBadge({ active }: { active: boolean }) {


### PR DESCRIPTION
## Summary
- refactor admin price and service pages to use client-side tables
- add dedicated table components with column definitions
- mark StatusBadge as a client component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b06129b69083288c7a75f10577ee97