### PR TITLE
Protect admin APIs and fix build error

### DIFF
--- a/app/admin/compras/ComprasTable.tsx
+++ b/app/admin/compras/ComprasTable.tsx
@@ -16,13 +16,16 @@ const ActionButtons = ({ id }: { id: string }) => {
   };
   return (
     <div className="flex gap-2">
-      <Button variant="outline" size="sm" onClick={() => update('APPROVED')}>
+      <Button
+        variant="outline"
+        className="h-8 px-3"
+        onClick={() => update('APPROVED')}
+      >
         Aprobar
       </Button>
       <Button
         variant="outline"
-        size="sm"
-        className="border-red-600 text-red-600 hover:bg-red-50 dark:border-red-600 dark:text-red-600 dark:hover:bg-red-950"
+        className="h-8 px-3 border-red-600 text-red-600 hover:bg-red-50 dark:border-red-600 dark:text-red-600 dark:hover:bg-red-950"
         onClick={() => update('REJECTED')}
       >
         Rechazar

--- a/app/api/purchases/[id]/status/route.ts
+++ b/app/api/purchases/[id]/status/route.ts
@@ -1,10 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
 import { prisma } from '@/lib/db';
+import { authOptions } from '@/lib/auth';
 
 export async function PATCH(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
   const { status } = await req.json();
   if (!['APPROVED', 'REJECTED'].includes(status)) {
     return NextResponse.json({ error: 'Invalid status' }, { status: 400 });

--- a/app/api/servicios/[id]/route.ts
+++ b/app/api/servicios/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
 import { prisma } from '@/lib/db';
 import { serviceSchema } from '@/lib/validations';
+import { authOptions } from '@/lib/auth';
 
 export async function GET(
   _req: NextRequest,
@@ -17,6 +19,10 @@ export async function PATCH(
   req: NextRequest,
   { params }: { params: { id: string } },
 ) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
   const data = await req.json();
   const parsed = serviceSchema.partial().safeParse(data);
   if (!parsed.success) {
@@ -33,6 +39,10 @@ export async function DELETE(
   _req: NextRequest,
   { params }: { params: { id: string } },
 ) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
   await prisma.service.delete({ where: { id: params.id } });
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- verify admin role before updating purchase status
- secure service update and delete API handlers with admin check
- remove unsupported `size` prop from admin purchase buttons to fix build

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0712439cc8328b1a7ce2ff4d62698