### PR TITLE
Handle Prisma data loss warning during deploy

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,5 +3,5 @@ services:
     name: subs
     env: node
     buildCommand: npm ci && npm run build
-    preDeployCommand: npx prisma db push && npx prisma db seed
+    preDeployCommand: npx prisma db push --accept-data-loss && npx prisma db seed
     startCommand: npm start


### PR DESCRIPTION
## Summary
- add `--accept-data-loss` flag to Prisma `db push` in Render pre-deploy step

## Testing
- `npx prisma db push --accept-data-loss` *(fails: Can't reach database server)*
- `npm run build` *(fails: Type error in app/api/checkout/manual/route.ts)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b089e5b1d483289754b1a12d052eaf