### PR TITLE
Restore order statuses to prevent Prisma data loss

### DIFF
--- a/app/api/checkout/manual/route.ts
+++ b/app/api/checkout/manual/route.ts
@@ -10,6 +10,7 @@ export async function POST(req: Request) {
     data: {
       email: 'guest@example.com',
       status: OrderStatus.PENDING,
+      subtotalCents: Math.round(total * 100),
       totalCents: Math.round(total * 100),
       currency: 'USDT',
       network: config?.network || '',

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,9 +16,11 @@ enum Role {
 enum OrderStatus {
   PENDING
   REVIEW
+  REQUIRES_PAYMENT
   PAID
   FAILED
-  CANCELED
+  CANCELED @map("CANCELLED")
+  REFUNDED
 }
 
 enum PaymentProvider {


### PR DESCRIPTION
## Summary
- restore removed `OrderStatus` enum values to avoid data loss errors
- ensure manual checkout populates `subtotalCents` along with `totalCents`

## Testing
- `npm test`
- `npx prisma db push` *(fails: Can't reach database server at `dpg-d2n6lih5pdvs73ck5mhg-a:5432`)*
- `npm run build` *(fails: Can't reach database server at `dpg-d2n6lih5pdvs73ck5mhg-a:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68b091474db08328b2ee3e864e9fc12f