### PR TITLE
fix: refresh services after admin changes

### DIFF
--- a/app/admin/servicios/nuevo/page.tsx
+++ b/app/admin/servicios/nuevo/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation';
+import { revalidatePath } from 'next/cache';
 import { prisma } from '@/lib/db';
 import { mkdir, writeFile } from 'fs/promises';
 import path from 'path';
@@ -47,6 +48,9 @@ export default function NuevoServicio() {
         }
       });
     }
+    // Invalidate the home page so new services become visible immediately
+    // after creation.
+    revalidatePath('/');
     redirect('/admin/servicios');
   }
 

--- a/components/Services.tsx
+++ b/components/Services.tsx
@@ -1,8 +1,13 @@
 import { prisma } from '@/lib/db';
+import { unstable_noStore as noStore } from 'next/cache';
 import { Code, Globe, Layers } from 'lucide-react';
 import { ServiceCard } from '@/components/ServiceCard';
 
 export async function Services() {
+  // Ensure services are fetched on every request so that changes in
+  // the admin panel (create/delete) are reflected immediately on the
+  // public site without requiring a rebuild.
+  noStore();
   let servicios: Array<{ id: string; name: string; description: string | null }> = [];
   try {
     servicios = await prisma.service.findMany({


### PR DESCRIPTION
## Summary
- fetch services without caching so home page reflects DB changes immediately
- revalidate home page when creating a new service in admin

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a43180208328a23e1d1610e1d0b8