### PR TITLE
Require account for checkout

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { z } from 'zod';
+import { hash } from 'bcryptjs';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6)
+});
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Datos inválidos' }, { status: 400 });
+  }
+  const existing = await prisma.user.findUnique({ where: { email: parsed.data.email } });
+  if (existing) {
+    return NextResponse.json({ error: 'El email ya está registrado' }, { status: 400 });
+  }
+  await prisma.user.create({
+    data: {
+      email: parsed.data.email,
+      passwordHash: await hash(parsed.data.password, 10)
+    }
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -1,34 +1,44 @@
 'use client';
 
 import { useState } from 'react';
-import { signIn } from 'next-auth/react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { signIn } from 'next-auth/react';
 
-export default function LoginPage() {
+export default function RegisterPage() {
   const router = useRouter();
   const search = useSearchParams();
-  const next = search.get('next') || '/admin';
+  const next = search.get('next') || '/checkout';
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
-  const doLogin = async () => {
+  const doRegister = async () => {
     setError('');
-    const res = await signIn('credentials', {
-      email,
-      password,
-      redirect: false,
+    const res = await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
     });
-    if (res?.ok) {
-      router.push(next);
+    if (res.ok) {
+      const signInRes = await signIn('credentials', {
+        email,
+        password,
+        redirect: false,
+      });
+      if (signInRes?.ok) {
+        router.push(next);
+      } else {
+        router.push('/auth/login');
+      }
     } else {
-      setError('Credenciales inválidas');
+      const data = await res.json();
+      setError(data.error || 'Error al registrarse');
     }
   };
 
   return (
     <div className="mx-auto max-w-md p-6">
-      <h1 className="mb-4 text-2xl font-bold">Login</h1>
+      <h1 className="mb-4 text-2xl font-bold">Crear cuenta</h1>
       <div className="space-y-3">
         <input
           className="w-full border p-2"
@@ -43,8 +53,8 @@ export default function LoginPage() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
-        <button className="border px-4 py-2" onClick={doLogin}>
-          Entrar
+        <button className="border px-4 py-2" onClick={doRegister}>
+          Registrarse
         </button>
         {error && <p className="text-sm text-red-500">{error}</p>}
       </div>

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,7 +1,14 @@
 import { Suspense } from 'react';
+import { getServerSession } from 'next-auth/next';
+import { redirect } from 'next/navigation';
 import CheckoutClient from './CheckoutClient';
+import { authOptions } from '@/lib/auth';
 
-export default function CheckoutPage() {
+export default async function CheckoutPage() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect('/auth/register?next=/checkout');
+  }
   return (
     <Suspense fallback={null}>
       <CheckoutClient />


### PR DESCRIPTION
## Summary
- enforce authentication on checkout with redirect to registration
- add user registration API and signup page
- allow login to redirect back to original page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0b9216f9c83288bcce0a8133179c5