### PR TITLE
Wrap auth pages in Suspense for search params

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { signIn } from 'next-auth/react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
-export default function LoginPage() {
+function LoginPageContent() {
   const router = useRouter();
   const search = useSearchParams();
   const next = search.get('next') || '/admin';
@@ -49,5 +49,13 @@ export default function LoginPage() {
         {error && <p className="text-sm text-red-500">{error}</p>}
       </div>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <LoginPageContent />
+    </Suspense>
   );
 }

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 
-export default function RegisterPage() {
+function RegisterPageContent() {
   const router = useRouter();
   const search = useSearchParams();
   const next = search.get('next') || '/checkout';
@@ -59,5 +59,13 @@ export default function RegisterPage() {
         {error && <p className="text-sm text-red-500">{error}</p>}
       </div>
     </div>
+  );
+}
+
+export default function RegisterPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <RegisterPageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- handle Next.js requirement by wrapping login and register pages in `<Suspense>`
- move page logic into inner components so `useSearchParams` is inside suspense boundary

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b0bbbd4944832880d148d991efd00e