### PR TITLE
feat: add ghost and icon button variants

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,24 +4,31 @@ import { cn } from '@/lib/utils';
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: boolean;
-  variant?: 'default' | 'outline';
+  variant?: 'default' | 'outline' | 'ghost';
+  size?: 'default' | 'icon';
 }
 
 const baseClasses =
-  'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
 
 const variants: Record<NonNullable<ButtonProps['variant']>, string> = {
   default: 'bg-blue-600 text-white hover:bg-blue-700',
-  outline: 'border border-blue-600 text-blue-600 hover:bg-blue-50'
+  outline: 'border border-blue-600 text-blue-600 hover:bg-blue-50',
+  ghost: 'text-blue-600 hover:bg-blue-50'
+};
+
+const sizes: Record<NonNullable<ButtonProps['size']>, string> = {
+  default: 'px-4 py-2',
+  icon: 'h-10 w-10'
 };
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, asChild = false, variant = 'default', ...props }, ref) => {
+  ({ className, asChild = false, variant = 'default', size = 'default', ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';
     return (
       <Comp
         ref={ref}
-        className={cn(baseClasses, variants[variant], className)}
+        className={cn(baseClasses, variants[variant], sizes[size], className)}
         {...props}
       />
     );


### PR DESCRIPTION
## Summary
- extend Button component with new `ghost` style and `icon` size
- support ThemeToggle usage of `variant="ghost"` and `size="icon"`

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Can't reach database server at dpg-d2n6lih5pdvs73ck5mhg-a:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c483654c83288ac9b692d25e2032