### PR TITLE
Add contact modal and admin message view

### DIFF
--- a/app/admin/mensajes/page.tsx
+++ b/app/admin/mensajes/page.tsx
@@ -1,0 +1,31 @@
+import { prisma } from '@/lib/db';
+import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
+
+export const revalidate = 0;
+
+export default async function MensajesPage() {
+  const mensajes = await prisma.contactMessage.findMany({
+    orderBy: { createdAt: 'desc' },
+  });
+
+  return (
+    <div>
+      <Breadcrumbs items={[{ label: 'Dashboard', href: '/admin' }, { label: 'Mensajes' }]} />
+      <div className="mt-4 space-y-4">
+        {mensajes.length === 0 && <p>No hay mensajes.</p>}
+        {mensajes.map((m) => (
+          <div key={m.id} className="rounded border bg-white p-4 shadow-sm">
+            <p className="font-semibold">
+              {m.name} ({m.email})
+            </p>
+            <p className="mt-2 whitespace-pre-wrap">{m.message}</p>
+            <p className="mt-2 text-sm text-gray-500">
+              {m.createdAt.toLocaleString()}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { contactSchema } from '@/lib/validations';
 import { Resend } from 'resend';
 import nodemailer from 'nodemailer';
+import { prisma } from '@/lib/db';
 
 export async function POST(req: Request) {
   const body = await req.json();
@@ -11,6 +12,7 @@ export async function POST(req: Request) {
   }
   const { name, email, message } = parsed.data;
   try {
+    await prisma.contactMessage.create({ data: { name, email, message } });
     if (process.env.RESEND_API_KEY) {
       const resend = new Resend(process.env.RESEND_API_KEY);
       await resend.emails.send({

--- a/app/carrito/page.tsx
+++ b/app/carrito/page.tsx
@@ -12,9 +12,9 @@ export default function CartPage() {
   }
 
   return (
-    <div className="container mx-auto p-4">
+    <div className="container mx-auto max-w-4xl p-4">
       <CartTable />
-      <div className="flex justify-end">
+      <div className="mt-6 flex justify-center">
         <CartSummary />
       </div>
     </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -27,15 +27,16 @@ function LoginPageContent() {
   };
 
   return (
-    <div className="mx-auto max-w-md p-6">
-      <h1 className="mb-4 text-2xl font-bold">Login</h1>
-      <div className="space-y-3">
-        <input
-          className="w-full border p-2"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="w-full max-w-md p-6">
+        <h1 className="mb-4 text-2xl font-bold">Login</h1>
+        <div className="space-y-3">
+          <input
+            className="w-full border p-2"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
         <input
           className="w-full border p-2"
           placeholder="Password"
@@ -46,7 +47,8 @@ function LoginPageContent() {
         <button className="border px-4 py-2" onClick={doLogin}>
           Entrar
         </button>
-        {error && <p className="text-sm text-red-500">{error}</p>}
+          {error && <p className="text-sm text-red-500">{error}</p>}
+        </div>
       </div>
     </div>
   );

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -37,15 +37,16 @@ function RegisterPageContent() {
   };
 
   return (
-    <div className="mx-auto max-w-md p-6">
-      <h1 className="mb-4 text-2xl font-bold">Crear cuenta</h1>
-      <div className="space-y-3">
-        <input
-          className="w-full border p-2"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="w-full max-w-md p-6">
+        <h1 className="mb-4 text-2xl font-bold">Crear cuenta</h1>
+        <div className="space-y-3">
+          <input
+            className="w-full border p-2"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
         <input
           className="w-full border p-2"
           placeholder="Password"
@@ -56,7 +57,8 @@ function RegisterPageContent() {
         <button className="border px-4 py-2" onClick={doRegister}>
           Registrarse
         </button>
-        {error && <p className="text-sm text-red-500">{error}</p>}
+          {error && <p className="text-sm text-red-500">{error}</p>}
+        </div>
       </div>
     </div>
   );

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,56 +1,15 @@
 'use client';
 
-import { useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { z } from 'zod';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { contactSchema } from '@/lib/validations';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Button } from '@/components/ui/button';
-
-type ContactValues = z.infer<typeof contactSchema>;
+import { ContactForm } from '@/components/ContactForm';
 
 export function Contact() {
-  const [submitted, setSubmitted] = useState(false);
-  const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { errors, isSubmitting }
-  } = useForm<ContactValues>({ resolver: zodResolver(contactSchema) });
-
-  const onSubmit = async (data: ContactValues) => {
-    await fetch('/api/contact', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data)
-    });
-    setSubmitted(true);
-    reset();
-  };
-
   return (
-    <section id="contacto" className="mx-auto max-w-md px-4 pt-[var(--section-pt)] pb-[var(--section-pb)]">
+    <section
+      id="contacto"
+      className="mx-auto max-w-md px-4 pt-[var(--section-pt)] pb-[var(--section-pb)]"
+    >
       <h2 className="mb-8 text-center text-3xl font-serif">Contacto</h2>
-      {submitted && <p className="mb-4 text-green-600">Mensaje enviado!</p>}
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-        <div>
-          <Input placeholder="Nombre" {...register('name')} aria-invalid={!!errors.name} />
-          {errors.name && <p className="mt-1 text-sm text-red-500">{errors.name.message}</p>}
-        </div>
-        <div>
-          <Input type="email" placeholder="Email" {...register('email')} aria-invalid={!!errors.email} />
-          {errors.email && <p className="mt-1 text-sm text-red-500">{errors.email.message}</p>}
-        </div>
-        <div>
-          <Textarea placeholder="Mensaje" rows={4} {...register('message')} aria-invalid={!!errors.message} />
-          {errors.message && <p className="mt-1 text-sm text-red-500">{errors.message.message}</p>}
-        </div>
-        <Button type="submit" disabled={isSubmitting} className="w-full">
-          {isSubmitting ? 'Enviando...' : 'Enviar'}
-        </Button>
-      </form>
+      <ContactForm />
     </section>
   );
 }

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { contactSchema } from '@/lib/validations';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+export type ContactValues = z.infer<typeof contactSchema>;
+
+interface Props {
+  onSubmitted?: () => void;
+}
+
+export function ContactForm({ onSubmitted }: Props) {
+  const [submitted, setSubmitted] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ContactValues>({ resolver: zodResolver(contactSchema) });
+
+  const onSubmit = async (data: ContactValues) => {
+    await fetch('/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    setSubmitted(true);
+    reset();
+    onSubmitted?.();
+  };
+
+  return (
+    <div>
+      {submitted && <p className="mb-4 text-green-600">Mensaje enviado!</p>}
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <Input placeholder="Nombre" {...register('name')} aria-invalid={!!errors.name} />
+          {errors.name && <p className="mt-1 text-sm text-red-500">{errors.name.message}</p>}
+        </div>
+        <div>
+          <Input type="email" placeholder="Email" {...register('email')} aria-invalid={!!errors.email} />
+          {errors.email && <p className="mt-1 text-sm text-red-500">{errors.email.message}</p>}
+        </div>
+        <div>
+          <Textarea placeholder="Mensaje" rows={4} {...register('message')} aria-invalid={!!errors.message} />
+          {errors.message && <p className="mt-1 text-sm text-red-500">{errors.message.message}</p>}
+        </div>
+        <Button type="submit" disabled={isSubmitting} className="w-full">
+          {isSubmitting ? 'Enviando...' : 'Enviar'}
+        </Button>
+      </form>
+    </div>
+  );
+}
+

--- a/components/ContactModal.tsx
+++ b/components/ContactModal.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useState } from 'react';
+import { ContactForm } from '@/components/ContactForm';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  triggerText?: string;
+}
+
+export function ContactModal({ triggerText = 'Consultar' }: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button variant="outline" className="w-full" onClick={() => setOpen(true)}>
+        {triggerText}
+      </Button>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-md rounded bg-white p-4 shadow-lg">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Enviar mensaje</h2>
+              <button onClick={() => setOpen(false)} className="text-gray-500">
+                ×
+              </button>
+            </div>
+            <ContactForm onSubmitted={() => setOpen(false)} />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+

--- a/components/ServiceCard.tsx
+++ b/components/ServiceCard.tsx
@@ -1,6 +1,6 @@
 import type { LucideIcon } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import { ContactModal } from '@/components/ContactModal';
 
 interface ServiceCardProps {
   icon: LucideIcon;
@@ -17,7 +17,7 @@ export function ServiceCard({ icon: Icon, title, description }: ServiceCardProps
       </CardHeader>
       <CardContent className="space-y-4">
         {description && <p className="text-sm text-zinc-600">{description}</p>}
-        <Button variant="outline" className="w-full">Consultar</Button>
+        <ContactModal />
       </CardContent>
     </Card>
   );

--- a/components/admin/AppSidebar.tsx
+++ b/components/admin/AppSidebar.tsx
@@ -3,12 +3,13 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
-import { Home, Package, ShoppingCart, Settings, X } from 'lucide-react';
+import { Home, Package, ShoppingCart, Settings, MessageSquare, X } from 'lucide-react';
 
 const links = [
   { href: '/admin', label: 'Dashboard', icon: Home },
   { href: '/admin/servicios', label: 'Servicios', icon: Package },
   { href: '/admin/compras', label: 'Compras', icon: ShoppingCart },
+  { href: '/admin/mensajes', label: 'Mensajes', icon: MessageSquare },
   { href: '/admin/ajustes', label: 'Ajustes', icon: Settings },
 ];
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -237,6 +237,15 @@ model AuditLog {
   createdAt DateTime @default(now())
 }
 
+model ContactMessage {
+  id        String   @id @default(cuid())
+  name      String
+  email     String
+  message   String
+  handled   Boolean  @default(false)
+  createdAt DateTime @default(now())
+}
+
 model Setting {
   id              Int             @id @default(1)
   defaultCurrency String          @default("USD")


### PR DESCRIPTION
## Summary
- add reusable contact form and modal for service inquiries
- store contact messages in database and expose admin messages page
- center auth and cart pages layout

## Testing
- `npx prisma generate`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1004ccbcc8328840f0d813799fd65