### PR TITLE
feat: manage site images from admin

### DIFF
--- a/app/admin/logos/[id]/page.tsx
+++ b/app/admin/logos/[id]/page.tsx
@@ -1,0 +1,64 @@
+import { prisma } from '@/lib/db';
+import { notFound, redirect } from 'next/navigation';
+import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
+import { Button } from '@/components/ui/button';
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+
+export default async function EditLogo({ params }: { params: { id: string } }) {
+  const logo = await prisma.logo.findUnique({ where: { id: params.id } });
+  if (!logo) notFound();
+
+  async function update(formData: FormData) {
+    'use server';
+    const image = formData.get('image') as File | null;
+    if (image && image.size > 0) {
+      const bytes = await image.arrayBuffer();
+      const buffer = Buffer.from(bytes);
+      const ext = path.extname(image.name) || '.png';
+      const filename = `${params.id}${ext}`;
+      const uploadDir = path.join(process.cwd(), 'public', 'logos');
+      await mkdir(uploadDir, { recursive: true });
+      await writeFile(path.join(uploadDir, filename), buffer);
+      await prisma.logo.update({ where: { id: params.id }, data: { imageUrl: `/logos/${filename}` } });
+    }
+    redirect('/admin/logos');
+  }
+
+  async function remove() {
+    'use server';
+    await prisma.logo.delete({ where: { id: params.id } });
+    redirect('/admin/logos');
+  }
+
+  return (
+    <div>
+      <Breadcrumbs items={[{ label: 'Logos', href: '/admin/logos' }, { label: 'Editar' }]} />
+      <form
+        action={update}
+        encType="multipart/form-data"
+        className="mx-auto mt-4 max-w-lg space-y-4 rounded-md bg-white p-4 shadow"
+      >
+        <div className="space-y-2">
+          <label htmlFor="image" className="block text-sm font-medium">
+            Logo
+          </label>
+          {logo.imageUrl && (
+            <img src={logo.imageUrl} alt="" className="mb-2 h-32 w-auto object-contain" />
+          )}
+          <input id="image" name="image" type="file" accept="image/*" className="w-full rounded-md border p-2" />
+        </div>
+        <Button type="submit">Guardar</Button>
+      </form>
+      <form action={remove} className="mx-auto mt-4 max-w-lg">
+        <Button
+          type="submit"
+          variant="outline"
+          className="w-full border-red-600 text-red-600 hover:bg-red-50"
+        >
+          Eliminar
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/app/admin/logos/nuevo/page.tsx
+++ b/app/admin/logos/nuevo/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from 'next/navigation';
+import { prisma } from '@/lib/db';
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+
+export default function NuevoLogo() {
+  async function create(formData: FormData) {
+    'use server';
+    const image = formData.get('image') as File | null;
+    if (!image || image.size === 0) return;
+    const logo = await prisma.logo.create({ data: { imageUrl: '' } });
+    const bytes = await image.arrayBuffer();
+    const buffer = Buffer.from(bytes);
+    const ext = path.extname(image.name) || '.png';
+    const filename = `${logo.id}${ext}`;
+    const uploadDir = path.join(process.cwd(), 'public', 'logos');
+    await mkdir(uploadDir, { recursive: true });
+    await writeFile(path.join(uploadDir, filename), buffer);
+    await prisma.logo.update({ where: { id: logo.id }, data: { imageUrl: `/logos/${filename}` } });
+    redirect('/admin/logos');
+  }
+
+  return (
+    <form action={create} encType="multipart/form-data" className="max-w-lg space-y-3 bg-white p-4">
+      <h1 className="text-xl font-bold">Nuevo logo</h1>
+      <input className="border p-2 w-full" type="file" accept="image/*" name="image" />
+      <button className="btn" type="submit">Crear</button>
+    </form>
+  );
+}

--- a/app/admin/logos/page.tsx
+++ b/app/admin/logos/page.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { prisma } from '@/lib/db';
+import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
+
+export const revalidate = 0;
+
+export default async function LogosPage() {
+  const logos = await prisma.logo.findMany({ orderBy: { createdAt: 'desc' } });
+  return (
+    <div>
+      <Breadcrumbs items={[{ label: 'Dashboard', href: '/admin' }, { label: 'Logos' }]} />
+      <div className="mt-4">
+        <Link href="/admin/logos/nuevo" className="btn mb-4 inline-block">
+          Nuevo
+        </Link>
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+          {logos.map((l) => (
+            <Link key={l.id} href={`/admin/logos/${l.id}`} className="block">
+              <Image src={l.imageUrl} alt="Logo" width={100} height={40} />
+            </Link>
+          ))}
+          {logos.length === 0 && <p>No hay logos.</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/proyectos/[id]/page.tsx
+++ b/app/admin/proyectos/[id]/page.tsx
@@ -1,0 +1,95 @@
+import { prisma } from '@/lib/db';
+import { notFound, redirect } from 'next/navigation';
+import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
+import { Button } from '@/components/ui/button';
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+
+export default async function EditProyecto({ params }: { params: { id: string } }) {
+  const project = await prisma.project.findUnique({ where: { id: params.id } });
+  if (!project) notFound();
+
+  async function update(formData: FormData) {
+    'use server';
+    const title = String(formData.get('title') || '');
+    await prisma.project.update({ where: { id: params.id }, data: { title } });
+    const image = formData.get('image') as File | null;
+    if (image && image.size > 0) {
+      const bytes = await image.arrayBuffer();
+      const buffer = Buffer.from(bytes);
+      const ext = path.extname(image.name) || '.png';
+      const filename = `${params.id}${ext}`;
+      const uploadDir = path.join(process.cwd(), 'public', 'projects');
+      await mkdir(uploadDir, { recursive: true });
+      await writeFile(path.join(uploadDir, filename), buffer);
+      await prisma.project.update({
+        where: { id: params.id },
+        data: { imageUrl: `/projects/${filename}` },
+      });
+    }
+    redirect('/admin/proyectos');
+  }
+
+  async function remove() {
+    'use server';
+    await prisma.project.delete({ where: { id: params.id } });
+    redirect('/admin/proyectos');
+  }
+
+  return (
+    <div>
+      <Breadcrumbs
+        items={[
+          { label: 'Proyectos', href: '/admin/proyectos' },
+          { label: 'Editar' },
+        ]}
+      />
+      <form
+        action={update}
+        encType="multipart/form-data"
+        className="mx-auto mt-4 max-w-lg space-y-4 rounded-md bg-white p-4 shadow"
+      >
+        <div className="space-y-2">
+          <label htmlFor="title" className="block text-sm font-medium">
+            Título
+          </label>
+          <input
+            id="title"
+            name="title"
+            defaultValue={project.title}
+            className="w-full rounded-md border p-2"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="image" className="block text-sm font-medium">
+            Imagen
+          </label>
+          {project.imageUrl && (
+            <img
+              src={project.imageUrl}
+              alt=""
+              className="mb-2 h-32 w-auto object-contain"
+            />
+          )}
+          <input
+            id="image"
+            name="image"
+            type="file"
+            accept="image/*"
+            className="w-full rounded-md border p-2"
+          />
+        </div>
+        <Button type="submit">Guardar</Button>
+      </form>
+      <form action={remove} className="mx-auto mt-4 max-w-lg">
+        <Button
+          type="submit"
+          variant="outline"
+          className="w-full border-red-600 text-red-600 hover:bg-red-50"
+        >
+          Eliminar
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/app/admin/proyectos/nuevo/page.tsx
+++ b/app/admin/proyectos/nuevo/page.tsx
@@ -1,0 +1,37 @@
+import { redirect } from 'next/navigation';
+import { prisma } from '@/lib/db';
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+
+export default function NuevoProyecto() {
+  async function create(formData: FormData) {
+    'use server';
+    const title = String(formData.get('title') || '');
+    const image = formData.get('image') as File | null;
+    if (!title) return;
+    const project = await prisma.project.create({ data: { title, imageUrl: '' } });
+    if (image && image.size > 0) {
+      const bytes = await image.arrayBuffer();
+      const buffer = Buffer.from(bytes);
+      const ext = path.extname(image.name) || '.png';
+      const filename = `${project.id}${ext}`;
+      const uploadDir = path.join(process.cwd(), 'public', 'projects');
+      await mkdir(uploadDir, { recursive: true });
+      await writeFile(path.join(uploadDir, filename), buffer);
+      await prisma.project.update({
+        where: { id: project.id },
+        data: { imageUrl: `/projects/${filename}` },
+      });
+    }
+    redirect('/admin/proyectos');
+  }
+
+  return (
+    <form action={create} encType="multipart/form-data" className="max-w-lg space-y-3 bg-white p-4">
+      <h1 className="text-xl font-bold">Nuevo proyecto</h1>
+      <input className="border p-2 w-full" name="title" placeholder="Título" />
+      <input className="border p-2 w-full" type="file" accept="image/*" name="image" />
+      <button className="btn" type="submit">Crear</button>
+    </form>
+  );
+}

--- a/app/admin/proyectos/page.tsx
+++ b/app/admin/proyectos/page.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { prisma } from '@/lib/db';
+import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
+
+export const revalidate = 0;
+
+export default async function ProyectosPage() {
+  const projects = await prisma.project.findMany({ orderBy: { createdAt: 'desc' } });
+  return (
+    <div>
+      <Breadcrumbs items={[{ label: 'Dashboard', href: '/admin' }, { label: 'Proyectos' }]} />
+      <div className="mt-4">
+        <Link href="/admin/proyectos/nuevo" className="btn mb-4 inline-block">
+          Nuevo
+        </Link>
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="text-left p-2">Título</th>
+              <th className="p-2">Imagen</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {projects.map((p) => (
+              <tr key={p.id} className="border-t">
+                <td className="p-2">{p.title}</td>
+                <td className="p-2">
+                  {p.imageUrl && <Image src={p.imageUrl} alt="" width={100} height={60} />}
+                </td>
+                <td className="p-2 text-right">
+                  <Link href={`/admin/proyectos/${p.id}`} className="text-blue-600">
+                    Editar
+                  </Link>
+                </td>
+              </tr>
+            ))}
+            {projects.length === 0 && (
+              <tr>
+                <td colSpan={3} className="p-2 text-center">
+                  No hay proyectos.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/components/LogoCloud.tsx
+++ b/components/LogoCloud.tsx
@@ -1,14 +1,17 @@
 import Image from 'next/image';
+import { prisma } from '@/lib/db';
+import { unstable_noStore as noStore } from 'next/cache';
 
-const logos = Array.from({ length: 5 }, (_, i) => `https://placehold.co/100x40?text=Logo+${i+1}&grayscale`);
-
-export function LogoCloud() {
+export async function LogoCloud() {
+  noStore();
+  const logos = await prisma.logo.findMany({ orderBy: { createdAt: 'desc' } });
   return (
     <section className="mx-auto max-w-7xl px-4 pt-[var(--section-pt)] pb-[var(--section-pb)]">
       <div className="flex flex-wrap items-center justify-center gap-6 opacity-70">
-        {logos.map((logo, i) => (
-          <Image key={i} src={logo} alt={`Logo ${i + 1}`} width={100} height={40} />
+        {logos.map(l => (
+          <Image key={l.id} src={l.imageUrl} alt="Logo" width={100} height={40} />
         ))}
+        {logos.length === 0 && <p>No hay logos disponibles.</p>}
       </div>
     </section>
   );

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -1,19 +1,18 @@
 import { ProjectCard } from '@/components/ProjectCard';
+import { prisma } from '@/lib/db';
+import { unstable_noStore as noStore } from 'next/cache';
 
-const projects = [
-  { title: 'Proyecto 1', image: 'https://placehold.co/600x400?text=Proyecto+1' },
-  { title: 'Proyecto 2', image: 'https://placehold.co/600x400?text=Proyecto+2' },
-  { title: 'Proyecto 3', image: 'https://placehold.co/600x400?text=Proyecto+3' }
-];
-
-export function Projects() {
+export async function Projects() {
+  noStore();
+  const projects = await prisma.project.findMany({ orderBy: { createdAt: 'desc' } });
   return (
     <section id="proyectos" className="mx-auto max-w-7xl px-4 pt-[var(--section-pt)] pb-[var(--section-pb)]">
       <h2 className="mb-12 text-center text-3xl font-serif">Proyectos</h2>
       <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-3">
         {projects.map(p => (
-          <ProjectCard key={p.title} title={p.title} image={p.image} />
+          <ProjectCard key={p.id} title={p.title} image={p.imageUrl} />
         ))}
+        {projects.length === 0 && <p>No hay proyectos disponibles.</p>}
       </div>
     </section>
   );

--- a/components/admin/AppSidebar.tsx
+++ b/components/admin/AppSidebar.tsx
@@ -3,11 +3,13 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
-import { Home, Package, ShoppingCart, Settings, MessageSquare, X } from 'lucide-react';
+import { Home, Package, ShoppingCart, Settings, MessageSquare, X, Image, GalleryHorizontalEnd } from 'lucide-react';
 
 const links = [
   { href: '/admin', label: 'Dashboard', icon: Home },
   { href: '/admin/servicios', label: 'Servicios', icon: Package },
+  { href: '/admin/proyectos', label: 'Proyectos', icon: Image },
+  { href: '/admin/logos', label: 'Logos', icon: GalleryHorizontalEnd },
   { href: '/admin/compras', label: 'Compras', icon: ShoppingCart },
   { href: '/admin/mensajes', label: 'Mensajes', icon: MessageSquare },
   { href: '/admin/ajustes', label: 'Ajustes', icon: Settings },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -268,3 +268,18 @@ model PaymentsConfig {
   updatedAt DateTime @updatedAt
 }
 
+model Project {
+  id        String   @id @default(cuid())
+  title     String
+  imageUrl  String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Logo {
+  id        String   @id @default(cuid())
+  imageUrl  String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+


### PR DESCRIPTION
## Summary
- add Project and Logo models for dynamic images
- enable editing project and logo images via admin
- show projects and logos from database on public pages

## Testing
- `npx prisma generate`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b114f0f3cc8328bcfa997c4a576e46