### PR TITLE
fix: render uploaded images

### DIFF
--- a/app/admin/logos/page.tsx
+++ b/app/admin/logos/page.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import Image from 'next/image';
 import { prisma } from '@/lib/db';
 import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
 
@@ -17,7 +16,7 @@ export default async function LogosPage() {
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
           {logos.map((l) => (
             <Link key={l.id} href={`/admin/logos/${l.id}`} className="block">
-              <Image src={l.imageUrl} alt="Logo" width={100} height={40} unoptimized />
+              <img src={l.imageUrl} alt="Logo" className="h-10 w-auto" />
             </Link>
           ))}
           {logos.length === 0 && <p>No hay logos.</p>}

--- a/app/admin/proyectos/page.tsx
+++ b/app/admin/proyectos/page.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import Image from 'next/image';
 import { prisma } from '@/lib/db';
 import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
 
@@ -28,7 +27,11 @@ export default async function ProyectosPage() {
                 <td className="p-2">{p.title}</td>
                 <td className="p-2">
                   {p.imageUrl && (
-                    <Image src={p.imageUrl} alt="" width={100} height={60} unoptimized />
+                    <img
+                      src={p.imageUrl}
+                      alt=""
+                      className="h-[60px] w-[100px] object-cover"
+                    />
                   )}
                 </td>
                 <td className="p-2 text-right">

--- a/components/LogoCloud.tsx
+++ b/components/LogoCloud.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { prisma } from '@/lib/db';
 import { unstable_noStore as noStore } from 'next/cache';
 
@@ -9,7 +8,12 @@ export async function LogoCloud() {
     <section className="mx-auto max-w-7xl px-4 pt-[var(--section-pt)] pb-[var(--section-pb)]">
       <div className="flex flex-wrap items-center justify-center gap-6 opacity-70">
         {logos.map((l) => (
-          <Image key={l.id} src={l.imageUrl} alt="Logo" width={100} height={40} unoptimized />
+          <img
+            key={l.id}
+            src={l.imageUrl}
+            alt="Logo"
+            className="h-10 w-auto"
+          />
         ))}
         {logos.length === 0 && <p>No hay logos disponibles.</p>}
       </div>

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { Card, CardContent } from '@/components/ui/card';
 
 interface ProjectCardProps {
@@ -10,13 +9,10 @@ interface ProjectCardProps {
 export function ProjectCard({ title, image, tags = [] }: ProjectCardProps) {
   return (
     <Card className="overflow-hidden shadow-soft transition-transform hover:-translate-y-1">
-      <Image
+      <img
         src={image}
         alt={title}
-        width={600}
-        height={400}
         className="h-40 w-full object-cover"
-        unoptimized
       />
       <CardContent className="p-4 space-y-2">
         <p className="font-medium">{title}</p>

--- a/components/cart/WalletBox.tsx
+++ b/components/cart/WalletBox.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Image from 'next/image';
 import { CopyButton } from './CopyButton';
 
 interface Props {
@@ -31,7 +30,7 @@ export function WalletBox({ address, qrUrl, network }: Props) {
       </a>
       {qrUrl && (
         <div className="mt-4">
-          <Image src={qrUrl} alt="QR" width={150} height={150} unoptimized />
+          <img src={qrUrl} alt="QR" className="h-[150px] w-[150px]" />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- use plain `<img>` tags for dynamic logos, projects, and QR code images
- ensure project and logo tables show uploaded images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1b8d78ff0832886accae2d6f568bd