### PR TITLE
Remove local domains in favor of Cloudinary images

### DIFF
--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,5 +1,5 @@
 export async function GET() {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  const baseUrl = process.env.PUBLIC_BASE_URL || 'https://example.com';
   return new Response(`User-agent: *\nAllow: /\nSitemap: ${baseUrl}/sitemap.xml`, {
     headers: { 'Content-Type': 'text/plain' }
   });

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  const baseUrl = process.env.PUBLIC_BASE_URL || 'https://example.com';
   return [
     { url: baseUrl, lastModified: new Date() },
     { url: `${baseUrl}/servicios`, lastModified: new Date() }

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 
-const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+const baseUrl = process.env.PUBLIC_BASE_URL || 'https://example.com';
 
 export const baseMetadata: Metadata = {
   metadataBase: new URL(baseUrl),

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,7 +6,7 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   images: {
-    domains: ['placehold.co'],
+    domains: ['res.cloudinary.com'],
   },
   webpack: (config) => {
     config.resolve.alias = {

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('login page renders', async ({ page }) => {
-  await page.goto('http://localhost:3000/auth/login');
+  const baseUrl = process.env.PUBLIC_BASE_URL!;
+  await page.goto(`${baseUrl}/auth/login`);
   await expect(page.locator('body')).toBeVisible();
 });

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
 
 test('landing has no admin link and ctas navigate', async ({ page }) => {
-  await page.goto('http://localhost:3000/');
+  const baseUrl = process.env.PUBLIC_BASE_URL!;
+  await page.goto(`${baseUrl}/`);
   await expect(page.getByText('Entrar al Admin')).toHaveCount(0);
   await page.getByRole('link', { name: 'Ver servicios' }).click();
   await expect(page.locator('#servicios')).toBeVisible();


### PR DESCRIPTION
## Summary
- allow only Cloudinary domain for Next.js images
- drop localhost defaults in metadata and robots/sitemap
- reference env-based base URL in e2e tests
- use PUBLIC_BASE_URL for metadata and tests to match Render config

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bc3baa5483289d16496e79586236