### PR TITLE
feat: manage multiple payment configs

### DIFF
--- a/app/admin/ajustes/page.tsx
+++ b/app/admin/ajustes/page.tsx
@@ -1,89 +1,124 @@
 import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
 import { prisma } from '@/lib/db';
-import { PaymentProvider } from '@prisma/client';
 import { mkdir, writeFile } from 'fs/promises';
 import path from 'path';
 
 export default async function AjustesPage() {
-  const settings = await prisma.setting.findUnique({ where: { id: 1 } });
+  const configs = await prisma.paymentsConfig.findMany();
 
-  async function save(formData: FormData) {
+  async function create(formData: FormData) {
     'use server';
     const network = String(formData.get('network') || '');
     const wallet = String(formData.get('wallet') || '');
     const qr = formData.get('qr') as File | null;
-    const existing = await prisma.setting.findUnique({ where: { id: 1 } });
-    let qrCodeUrl = existing?.qrCodeUrl;
+    let qrUrl: string | undefined;
     if (qr && qr.size > 0) {
       const bytes = await qr.arrayBuffer();
       const buffer = Buffer.from(bytes);
       const ext = path.extname(qr.name) || '.png';
-      const filename = `qr${ext}`;
+      const filename = `${Date.now()}${ext}`;
       const uploadDir = path.join(process.cwd(), 'public', 'payments');
       await mkdir(uploadDir, { recursive: true });
       await writeFile(path.join(uploadDir, filename), buffer);
-      qrCodeUrl = `/payments/${filename}`;
+      qrUrl = `/payments/${filename}`;
     }
-    await prisma.setting.upsert({
-      where: { id: 1 },
-      update: {
-        cryptoNetwork: network,
-        walletAddress: wallet,
-        qrCodeUrl,
-      },
-      create: {
-        id: 1,
-        paymentProvider: PaymentProvider.COINBASE,
-        defaultCurrency: 'USD',
-        cryptoNetwork: network,
-        walletAddress: wallet,
-        qrCodeUrl,
+    await prisma.paymentsConfig.create({
+      data: { network, wallet, qrUrl },
+    });
+  }
+
+  async function update(formData: FormData) {
+    'use server';
+    const id = Number(formData.get('id'));
+    const network = String(formData.get('network') || '');
+    const wallet = String(formData.get('wallet') || '');
+    const qr = formData.get('qr') as File | null;
+    let qrUrl: string | undefined;
+    if (qr && qr.size > 0) {
+      const bytes = await qr.arrayBuffer();
+      const buffer = Buffer.from(bytes);
+      const ext = path.extname(qr.name) || '.png';
+      const filename = `${Date.now()}${ext}`;
+      const uploadDir = path.join(process.cwd(), 'public', 'payments');
+      await mkdir(uploadDir, { recursive: true });
+      await writeFile(path.join(uploadDir, filename), buffer);
+      qrUrl = `/payments/${filename}`;
+    }
+    await prisma.paymentsConfig.update({
+      where: { id },
+      data: {
+        network,
+        wallet,
+        ...(qrUrl ? { qrUrl } : {}),
       },
     });
   }
 
+  async function remove(formData: FormData) {
+    'use server';
+    const id = Number(formData.get('id'));
+    await prisma.paymentsConfig.delete({ where: { id } });
+  }
+
   return (
-    <div>
+    <div className="space-y-6">
       <Breadcrumbs items={[{ label: 'Dashboard', href: '/admin' }, { label: 'Ajustes' }]} />
-      <form
-        action={save}
-        encType="multipart/form-data"
-        className="space-y-4 rounded-2xl bg-white p-6 shadow"
-      >
+
+      {configs.map((cfg) => (
+        <div key={cfg.id} className="space-y-2 rounded-2xl bg-white p-6 shadow">
+          <form action={update} encType="multipart/form-data" className="space-y-4">
+            <input type="hidden" name="id" value={cfg.id} />
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Red</label>
+              <input
+                name="network"
+                defaultValue={cfg.network}
+                className="mt-1 w-full border p-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Billetera</label>
+              <input
+                name="wallet"
+                defaultValue={cfg.wallet}
+                className="mt-1 w-full border p-2"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">Código QR</label>
+              {cfg.qrUrl && (
+                <img src={cfg.qrUrl} alt="QR actual" className="mb-2 h-32 w-32 object-cover" />
+              )}
+              <input type="file" accept="image/*" name="qr" className="mt-1 w-full border p-2" />
+            </div>
+            <button type="submit" className="btn">
+              Guardar
+            </button>
+          </form>
+          <form action={remove}>
+            <input type="hidden" name="id" value={cfg.id} />
+            <button type="submit" className="btn bg-red-600 text-white">
+              Eliminar
+            </button>
+          </form>
+        </div>
+      ))}
+
+      <form action={create} encType="multipart/form-data" className="space-y-4 rounded-2xl bg-white p-6 shadow">
         <div>
           <label className="block text-sm font-medium text-gray-700">Red</label>
-          <input
-            name="network"
-            defaultValue={settings?.cryptoNetwork ?? ''}
-            className="mt-1 w-full border p-2"
-          />
+          <input name="network" className="mt-1 w-full border p-2" />
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-700">Billetera</label>
-          <input
-            name="wallet"
-            defaultValue={settings?.walletAddress ?? ''}
-            className="mt-1 w-full border p-2"
-          />
+          <input name="wallet" className="mt-1 w-full border p-2" />
         </div>
         <div>
           <label className="block text-sm font-medium text-gray-700">Código QR</label>
-          {settings?.qrCodeUrl && (
-            <img
-              src={settings.qrCodeUrl}
-              alt="QR actual"
-              className="mb-2 h-32 w-32 object-cover"
-            />
-          )}
-          <input
-            type="file"
-            accept="image/*"
-            name="qr"
-            className="mt-1 w-full border p-2"
-          />
+          <input type="file" accept="image/*" name="qr" className="mt-1 w-full border p-2" />
         </div>
         <button type="submit" className="btn">
-          Guardar
+          Agregar
         </button>
       </form>
     </div>

--- a/app/comprar/page.tsx
+++ b/app/comprar/page.tsx
@@ -7,21 +7,25 @@ interface Props {
 }
 
 export default async function ComprarPage({ searchParams }: Props) {
-  const settings = await prisma.setting.findUnique({ where: { id: 1 } });
+  const payments = await prisma.paymentsConfig.findMany();
   const plan = searchParams.plan;
   return (
     <div className="container space-y-4">
       <h1 className="text-2xl font-bold">Carrito</h1>
       {plan && <p>Plan seleccionado: {plan}</p>}
-      {settings?.cryptoNetwork && <p>Red: {settings.cryptoNetwork}</p>}
-      {settings?.walletAddress && <p>Billetera: {settings.walletAddress}</p>}
-      {settings?.qrCodeUrl && (
-        <img
-          src={settings.qrCodeUrl}
-          alt="Código QR"
-          className="h-48 w-48 object-cover"
-        />
-      )}
+      {payments.map((p) => (
+        <div key={p.id} className="space-y-2">
+          <p>Red: {p.network}</p>
+          <p>Billetera: {p.wallet}</p>
+          {p.qrUrl && (
+            <img
+              src={p.qrUrl}
+              alt="Código QR"
+              className="h-48 w-48 object-cover"
+            />
+          )}
+        </div>
+      ))}
     </div>
   );
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -259,7 +259,7 @@ model Setting {
 }
 
 model PaymentsConfig {
-  id        Int      @id @default(1)
+  id        Int      @id @default(autoincrement())
   network   String
   wallet    String
   qrUrl     String?


### PR DESCRIPTION
## Summary
- allow adding, editing and removing payment configs with network, wallet and QR image
- show all payment configs during purchase
- support multiple payment records in database schema

## Testing
- `npx prisma generate`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e5e76f948328b1ac5ca5cf642e9b