### PR TITLE
Handle invalid JSON responses from API calls

### DIFF
--- a/app/checkout/CheckoutClient.tsx
+++ b/app/checkout/CheckoutClient.tsx
@@ -19,9 +19,19 @@ export default function CheckoutClient() {
   const orderId = searchParams.get('orderId');
 
   useEffect(() => {
-    fetch('/api/admin/payments-config')
-      .then((r) => r.json())
-      .then(setConfig);
+    const loadConfig = async () => {
+      try {
+        const r = await fetch('/api/admin/payments-config');
+        if (!r.ok) {
+          console.error('Failed to fetch payments config', await r.text());
+          return;
+        }
+        setConfig(await r.json());
+      } catch (err) {
+        console.error('Failed to fetch payments config', err);
+      }
+    };
+    loadConfig();
   }, []);
 
   const start = async () => {
@@ -30,6 +40,10 @@ export default function CheckoutClient() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ items })
     });
+    if (!res.ok) {
+      console.error('Failed to start checkout', await res.text());
+      return;
+    }
     const data = await res.json();
     window.history.replaceState(null, '', `/checkout?orderId=${data.id}`);
     setStep(1);

--- a/components/cart/NetworkSelector.tsx
+++ b/components/cart/NetworkSelector.tsx
@@ -21,9 +21,20 @@ export function NetworkSelector({
   const [config, setConfig] = useState<Config | null>(null);
 
   useEffect(() => {
-    fetch('/api/admin/payments-config')
-      .then((r) => r.json())
-      .then((data) => setConfig(data));
+    const loadConfig = async () => {
+      try {
+        const r = await fetch('/api/admin/payments-config');
+        if (!r.ok) {
+          console.error('Failed to fetch payments config', await r.text());
+          return;
+        }
+        const data = await r.json();
+        setConfig(data);
+      } catch (err) {
+        console.error('Failed to fetch payments config', err);
+      }
+    };
+    loadConfig();
   }, []);
 
   const options = config?.provider === 'manual' ? NETWORKS : [config?.network || ''];


### PR DESCRIPTION
## Summary
- guard against non-OK responses when loading payments config
- surface checkout start failures instead of parsing invalid JSON

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e7b510748328a8caa611655d0f9a