### PR TITLE
Upload admin images to Cloudinary

### DIFF
--- a/app/admin/ajustes/page.tsx
+++ b/app/admin/ajustes/page.tsx
@@ -1,7 +1,6 @@
 import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
 import { prisma } from '@/lib/db';
-import { mkdir, writeFile } from 'fs/promises';
-import path from 'path';
+import { saveImage } from '@/lib/upload';
 
 export default async function AjustesPage() {
   const configs = await prisma.paymentsConfig.findMany();
@@ -13,14 +12,7 @@ export default async function AjustesPage() {
     const qr = formData.get('qr') as File | null;
     let qrUrl: string | undefined;
     if (qr && qr.size > 0) {
-      const bytes = await qr.arrayBuffer();
-      const buffer = Buffer.from(bytes);
-      const ext = path.extname(qr.name) || '.png';
-      const filename = `${Date.now()}${ext}`;
-      const uploadDir = path.join(process.cwd(), 'public', 'payments');
-      await mkdir(uploadDir, { recursive: true });
-      await writeFile(path.join(uploadDir, filename), buffer);
-      qrUrl = `/payments/${filename}`;
+      qrUrl = await saveImage(qr, 'payments');
     }
     await prisma.paymentsConfig.create({
       data: { network, wallet, qrUrl },
@@ -35,14 +27,7 @@ export default async function AjustesPage() {
     const qr = formData.get('qr') as File | null;
     let qrUrl: string | undefined;
     if (qr && qr.size > 0) {
-      const bytes = await qr.arrayBuffer();
-      const buffer = Buffer.from(bytes);
-      const ext = path.extname(qr.name) || '.png';
-      const filename = `${Date.now()}${ext}`;
-      const uploadDir = path.join(process.cwd(), 'public', 'payments');
-      await mkdir(uploadDir, { recursive: true });
-      await writeFile(path.join(uploadDir, filename), buffer);
-      qrUrl = `/payments/${filename}`;
+      qrUrl = await saveImage(qr, 'payments');
     }
     await prisma.paymentsConfig.update({
       where: { id },

--- a/app/admin/logos/[id]/page.tsx
+++ b/app/admin/logos/[id]/page.tsx
@@ -2,7 +2,7 @@ import { prisma } from '@/lib/db';
 import { notFound, redirect } from 'next/navigation';
 import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
 import { Button } from '@/components/ui/button';
-import { saveLogo } from '@/lib/upload';
+import { saveImage } from '@/lib/upload';
 
 export default async function EditLogo({ params }: { params: { id: string } }) {
   const logo = await prisma.logo.findUnique({ where: { id: params.id } });
@@ -12,7 +12,7 @@ export default async function EditLogo({ params }: { params: { id: string } }) {
     'use server';
     const image = formData.get('image') as File | null;
     if (image && image.size > 0) {
-      const url = await saveLogo(image, params.id);
+      const url = await saveImage(image, 'logos', params.id);
       await prisma.logo.update({ where: { id: params.id }, data: { imageUrl: url } });
     }
     redirect('/admin/logos');

--- a/app/admin/logos/nuevo/page.tsx
+++ b/app/admin/logos/nuevo/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation';
 import { prisma } from '@/lib/db';
-import { saveLogo } from '@/lib/upload';
+import { saveImage } from '@/lib/upload';
 
 export default function NuevoLogo() {
   async function create(formData: FormData) {
@@ -8,7 +8,7 @@ export default function NuevoLogo() {
     const image = formData.get('image') as File | null;
     if (!image || image.size === 0) return;
     const logo = await prisma.logo.create({ data: { imageUrl: '' } });
-    const url = await saveLogo(image, logo.id);
+    const url = await saveImage(image, 'logos', logo.id);
     await prisma.logo.update({ where: { id: logo.id }, data: { imageUrl: url } });
     redirect('/admin/logos');
   }

--- a/app/admin/servicios/[id]/page.tsx
+++ b/app/admin/servicios/[id]/page.tsx
@@ -2,8 +2,7 @@ import { prisma } from '@/lib/db';
 import { notFound, redirect } from 'next/navigation';
 import { Breadcrumbs } from '@/components/admin/Breadcrumbs';
 import { Button } from '@/components/ui/button';
-import { mkdir, writeFile } from 'fs/promises';
-import path from 'path';
+import { saveImage } from '@/lib/upload';
 
 export default async function EditServicio({
   params,
@@ -25,16 +24,10 @@ export default async function EditServicio({
     });
     const image = formData.get('image') as File | null;
     if (image && image.size > 0) {
-      const bytes = await image.arrayBuffer();
-      const buffer = Buffer.from(bytes);
-      const ext = path.extname(image.name) || '.png';
-      const filename = `${params.id}${ext}`;
-      const uploadDir = path.join(process.cwd(), 'public', 'services');
-      await mkdir(uploadDir, { recursive: true });
-      await writeFile(path.join(uploadDir, filename), buffer);
+      const url = await saveImage(image, 'services', params.id);
       await prisma.service.update({
         where: { id: params.id },
-        data: { imageUrl: `/services/${filename}` },
+        data: { imageUrl: url },
       });
     }
     redirect('/admin/servicios');


### PR DESCRIPTION
## Summary
- add generic `saveImage` helper for Cloudinary or local storage
- use `saveImage` across admin pages for logos, projects, services and payment QR codes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb31ccd6908328b410f7558e965038