### PR TITLE
fix: enable cloudinary uploads

### DIFF
--- a/env.mjs
+++ b/env.mjs
@@ -13,6 +13,7 @@ const envSchema = z.object({
   CLOUDINARY_CLOUD_NAME: z.string().optional(),
   CLOUDINARY_API_KEY: z.string().optional(),
   CLOUDINARY_API_SECRET: z.string().optional(),
+  CLOUDINARY_URL: z.string().optional(),
   PAYMENT_PROVIDER: z.enum(['coinbase', 'stripe']).default('coinbase'),
   COINBASE_COMMERCE_API_KEY: z.string().optional(),
   COINBASE_COMMERCE_WEBHOOK_SECRET: z.string().optional(),

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -15,15 +15,20 @@ export async function saveImage(
   const filename = `${uniqueId}${ext}`;
 
   if (
-    env.CLOUDINARY_CLOUD_NAME &&
-    env.CLOUDINARY_API_KEY &&
-    env.CLOUDINARY_API_SECRET
+    env.CLOUDINARY_URL ||
+    (env.CLOUDINARY_CLOUD_NAME &&
+      env.CLOUDINARY_API_KEY &&
+      env.CLOUDINARY_API_SECRET)
   ) {
-    cloudinary.config({
-      cloud_name: env.CLOUDINARY_CLOUD_NAME,
-      api_key: env.CLOUDINARY_API_KEY,
-      api_secret: env.CLOUDINARY_API_SECRET,
-    });
+    cloudinary.config(
+      env.CLOUDINARY_URL
+        ? { secure: true }
+        : {
+            cloud_name: env.CLOUDINARY_CLOUD_NAME,
+            api_key: env.CLOUDINARY_API_KEY,
+            api_secret: env.CLOUDINARY_API_SECRET,
+          }
+    );
 
     const publicId = `${folder}/${uniqueId}`;
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,9 +7,9 @@ const nextConfig = {
   },
   images: {
     remotePatterns: [
-      { protocol: 'https', hostname: 'res.cloudinary.com' },
-      { protocol: 'https', hostname: 'images.unsplash.com' },
-      { protocol: 'https', hostname: 'avatars.githubusercontent.com' },
+      { protocol: 'https', hostname: 'res.cloudinary.com', pathname: '/**' },
+      { protocol: 'https', hostname: 'images.unsplash.com', pathname: '/**' },
+      { protocol: 'https', hostname: 'avatars.githubusercontent.com', pathname: '/**' },
     ],
   },
   webpack: (config) => {


### PR DESCRIPTION
## Summary
- support `CLOUDINARY_URL` in environment config
- allow uploading to Cloudinary when only a connection URL is provided
- fix remote image patterns for Cloudinary and other providers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb72bae2908328a3855e9190551491