### PR TITLE
Fix null logo Cloudinary deletion

### DIFF
--- a/app/admin/logos/[id]/page.tsx
+++ b/app/admin/logos/[id]/page.tsx
@@ -14,7 +14,7 @@ export default async function EditLogo({ params }: { params: { id: string } }) {
     const imageUrl = formData.get('imageUrl') as string | null;
     const imagePublicId = formData.get('imagePublicId') as string | null;
     if (imageUrl) {
-      if (logo.imagePublicId) {
+      if (logo?.imagePublicId) {
         await cloudinary.uploader.destroy(logo.imagePublicId);
       }
       await prisma.logo.update({
@@ -27,7 +27,7 @@ export default async function EditLogo({ params }: { params: { id: string } }) {
 
   async function remove() {
     'use server';
-    if (logo.imagePublicId) {
+    if (logo?.imagePublicId) {
       await cloudinary.uploader.destroy(logo.imagePublicId);
     }
     await prisma.logo.deleteMany({ where: { id: params.id } });


### PR DESCRIPTION
## Summary
- check logo image ID before deleting from Cloudinary to avoid null errors

## Testing
- `npx tsc --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb7ae5bc3c83288ca3616ff24facc2