### PR TITLE
fix: allow file uploads in logo forms

### DIFF
--- a/app/admin/logos/[id]/page.tsx
+++ b/app/admin/logos/[id]/page.tsx
@@ -39,6 +39,7 @@ export default async function EditLogo({ params }: { params: { id: string } }) {
       <Breadcrumbs items={[{ label: 'Logos', href: '/admin/logos' }, { label: 'Editar' }]} />
       <form
         action={update}
+        encType="multipart/form-data"
         className="mx-auto mt-4 max-w-lg space-y-4 rounded-md bg-white p-4 shadow"
       >
         <div className="space-y-2">

--- a/app/admin/logos/nuevo/page.tsx
+++ b/app/admin/logos/nuevo/page.tsx
@@ -15,7 +15,7 @@ export default function NuevoLogo() {
   }
 
   return (
-    <form action={create} className="max-w-lg space-y-3 bg-white p-4">
+    <form action={create} encType="multipart/form-data" className="max-w-lg space-y-3 bg-white p-4">
       <h1 className="text-xl font-bold">Nuevo logo</h1>
       <ImageUploadField folder="logos" />
       <button className="btn" type="submit">Crear</button>


### PR DESCRIPTION
## Summary
- ensure logo create/edit forms use multipart encoding for image uploads

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb7f985efc83288b0b6c9b06e9accb