### PR TITLE
Enable user-linked purchases and unlockable content

### DIFF
--- a/app/api/purchases/route.ts
+++ b/app/api/purchases/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/db';
 
 export async function POST(req: NextRequest) {
@@ -24,11 +26,13 @@ export async function POST(req: NextRequest) {
   if (!cart) {
     return NextResponse.json({ error: 'Cart not found' }, { status: 404 });
   }
+  const session = await getServerSession(authOptions);
   const purchase = await prisma.purchase.create({
     data: {
       status: 'PENDING',
       txHash,
       network,
+      userId: session?.user?.id,
       items: {
         create: cart.items.map((item) => ({
           serviceId: item.serviceId,

--- a/app/compras/page.tsx
+++ b/app/compras/page.tsx
@@ -1,0 +1,45 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+
+export const revalidate = 0;
+
+export default async function ComprasPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    redirect('/login?next=/compras');
+  }
+  const purchases = await prisma.purchase.findMany({
+    where: { userId: session.user.id },
+    include: { items: { include: { service: true } } },
+    orderBy: { createdAt: 'desc' }
+  });
+
+  return (
+    <div className="container py-8">
+      <h1 className="mb-6 text-3xl font-bold">Mis compras</h1>
+      {purchases.length === 0 ? (
+        <p>No has realizado compras todavía.</p>
+      ) : (
+        <ul className="space-y-4">
+          {purchases.map((p) => (
+            <li key={p.id} className="rounded border p-4">
+              <p className="mb-2 text-sm text-muted-foreground">
+                {p.createdAt.toLocaleDateString()}
+              </p>
+              <ul className="list-disc space-y-1 pl-5">
+                {p.items.map((it) => (
+                  <li key={it.id}>
+                    <Link href={`/servicios/${it.serviceId}`}>{it.service.name}</Link>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/servicios/[id]/page.tsx
+++ b/app/servicios/[id]/page.tsx
@@ -1,0 +1,41 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { notFound, redirect } from 'next/navigation';
+
+interface Props {
+  params: { id: string };
+}
+
+export const revalidate = 0;
+
+export default async function ServiceDetailPage({ params }: Props) {
+  const service = await prisma.service.findUnique({ where: { id: params.id } });
+  if (!service) {
+    notFound();
+  }
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    redirect(`/login?next=/servicios/${params.id}`);
+  }
+  const purchased = await prisma.purchaseItem.findFirst({
+    where: {
+      serviceId: service.id,
+      purchase: { userId: session.user.id }
+    }
+  });
+  if (!purchased) {
+    return (
+      <div className="container py-8">
+        <h1 className="mb-4 text-3xl font-bold">{service.name}</h1>
+        <p>No has comprado este servicio todavía.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="container py-8">
+      <h1 className="mb-4 text-3xl font-bold">{service.name}</h1>
+      {service.description ? <p>{service.description}</p> : <p>Contenido desbloqueado.</p>}
+    </div>
+  );
+}

--- a/components/ui/SiteHeader.tsx
+++ b/components/ui/SiteHeader.tsx
@@ -15,6 +15,9 @@ export function SiteHeader() {
         </Link>
         <div className="flex items-center gap-4">
           <ThemeToggle />
+          <Link href="/compras" className="text-sm font-medium">
+            Mis compras
+          </Link>
           <Link
             href="/carrito"
             className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"


### PR DESCRIPTION
## Summary
- Associate purchases with logged-in users
- Add "Mis compras" section showing purchased services
- Gate service detail pages to unlock content only for buyers
- Link to user purchases from site header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf65f4dcf0832883f17e16945632d4