### PR TITLE
Improve authentication flow and dynamic pricing display

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 export default async function AdminLayout({ children }: { children: ReactNode }) {
   const session = (await getServerSession(authOptions)) as Session | null;
   if (!session || session.user.role !== 'ADMIN') {
-    redirect('/auth/login');
+    redirect('/login');
   }
   return (
     <div className={`${playfair.variable} ${inter.variable}`}>

--- a/app/api/auth/check-email/route.ts
+++ b/app/api/auth/check-email/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/db';
+import { z } from 'zod';
+
+const schema = z.object({ email: z.string().email() });
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const email = url.searchParams.get('email') || '';
+  const parsed = schema.safeParse({ email });
+  if (!parsed.success) {
+    return NextResponse.json({ exists: false, error: 'Email inválido' }, { status: 400 });
+  }
+  const user = await prisma.user.findUnique({ where: { email: parsed.data.email } });
+  return NextResponse.json({ exists: Boolean(user) });
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,61 +1,10 @@
-'use client';
+import { Suspense } from 'react';
+import { LoginForm } from '@/components/auth/LoginForm';
 
-import { Suspense, useState } from 'react';
-import { signIn } from 'next-auth/react';
-import { useRouter, useSearchParams } from 'next/navigation';
-
-function LoginPageContent() {
-  const router = useRouter();
-  const search = useSearchParams();
-  const next = search.get('next') || '/admin';
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
-
-  const doLogin = async () => {
-    setError('');
-    const res = await signIn('credentials', {
-      email,
-      password,
-      redirect: false,
-    });
-    if (res?.ok) {
-      router.push(next);
-    } else {
-      setError('Credenciales inválidas');
-    }
-  };
-
+export default function AuthLoginPage() {
   return (
-    <div className="mx-auto max-w-md p-6">
-      <h1 className="mb-4 text-2xl font-bold">Login</h1>
-      <div className="space-y-3">
-        <input
-          className="w-full border p-2"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <input
-          className="w-full border p-2"
-          placeholder="Password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button className="border px-4 py-2" onClick={doLogin}>
-          Entrar
-        </button>
-        {error && <p className="text-sm text-red-500">{error}</p>}
-      </div>
-    </div>
-  );
-}
-
-export default function LoginPage() {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <LoginPageContent />
+    <Suspense fallback={<div className="flex min-h-[70vh] items-center justify-center">Cargando…</div>}>
+      <LoginForm />
     </Suspense>
   );
 }

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -1,71 +1,10 @@
-'use client';
+import { Suspense } from 'react';
+import { RegisterForm } from '@/components/auth/RegisterForm';
 
-import { Suspense, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { signIn } from 'next-auth/react';
-
-function RegisterPageContent() {
-  const router = useRouter();
-  const search = useSearchParams();
-  const next = search.get('next') || '/checkout';
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
-
-  const doRegister = async () => {
-    setError('');
-    const res = await fetch('/api/auth/register', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
-    });
-    if (res.ok) {
-      const signInRes = await signIn('credentials', {
-        email,
-        password,
-        redirect: false,
-      });
-      if (signInRes?.ok) {
-        router.push(next);
-      } else {
-        router.push('/auth/login');
-      }
-    } else {
-      const data = await res.json();
-      setError(data.error || 'Error al registrarse');
-    }
-  };
-
+export default function AuthRegisterPage() {
   return (
-    <div className="mx-auto max-w-md p-6">
-      <h1 className="mb-4 text-2xl font-bold">Crear cuenta</h1>
-      <div className="space-y-3">
-        <input
-          className="w-full border p-2"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <input
-          className="w-full border p-2"
-          placeholder="Password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button className="border px-4 py-2" onClick={doRegister}>
-          Registrarse
-        </button>
-        {error && <p className="text-sm text-red-500">{error}</p>}
-      </div>
-    </div>
-  );
-}
-
-export default function RegisterPage() {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <RegisterPageContent />
+    <Suspense fallback={<div className="flex min-h-[70vh] items-center justify-center">Cargando…</div>}>
+      <RegisterForm />
     </Suspense>
   );
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,63 +1,10 @@
-'use client';
-
-import { Suspense, useState } from 'react';
-import { signIn } from 'next-auth/react';
-import { useRouter, useSearchParams } from 'next/navigation';
-
-function LoginPageContent() {
-  const router = useRouter();
-  const search = useSearchParams();
-  const next = search.get('next') || '/admin';
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
-
-  const doLogin = async () => {
-    setError('');
-    const res = await signIn('credentials', {
-      email,
-      password,
-      redirect: false,
-    });
-    if (res?.ok) {
-      router.push(next);
-    } else {
-      setError('Credenciales inválidas');
-    }
-  };
-
-  return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="w-full max-w-md p-6">
-        <h1 className="mb-4 text-2xl font-bold">Login</h1>
-        <div className="space-y-3">
-          <input
-            className="w-full border p-2"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-        <input
-          className="w-full border p-2"
-          placeholder="Password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button className="border px-4 py-2" onClick={doLogin}>
-          Entrar
-        </button>
-          {error && <p className="text-sm text-red-500">{error}</p>}
-        </div>
-      </div>
-    </div>
-  );
-}
+import { Suspense } from 'react';
+import { LoginForm } from '@/components/auth/LoginForm';
 
 export default function LoginPage() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <LoginPageContent />
+    <Suspense fallback={<div className="flex min-h-[70vh] items-center justify-center">Cargando…</div>}>
+      <LoginForm />
     </Suspense>
   );
 }

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,73 +1,10 @@
-'use client';
-
-import { Suspense, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { signIn } from 'next-auth/react';
-
-function RegisterPageContent() {
-  const router = useRouter();
-  const search = useSearchParams();
-  const next = search.get('next') || '/checkout';
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
-
-  const doRegister = async () => {
-    setError('');
-    const res = await fetch('/api/auth/register', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password }),
-    });
-    if (res.ok) {
-      const signInRes = await signIn('credentials', {
-        email,
-        password,
-        redirect: false,
-      });
-      if (signInRes?.ok) {
-        router.push(next);
-      } else {
-        router.push('/auth/login');
-      }
-    } else {
-      const data = await res.json();
-      setError(data.error || 'Error al registrarse');
-    }
-  };
-
-  return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="w-full max-w-md p-6">
-        <h1 className="mb-4 text-2xl font-bold">Crear cuenta</h1>
-        <div className="space-y-3">
-          <input
-            className="w-full border p-2"
-            placeholder="Email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-          />
-        <input
-          className="w-full border p-2"
-          placeholder="Password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button className="border px-4 py-2" onClick={doRegister}>
-          Registrarse
-        </button>
-          {error && <p className="text-sm text-red-500">{error}</p>}
-        </div>
-      </div>
-    </div>
-  );
-}
+import { Suspense } from 'react';
+import { RegisterForm } from '@/components/auth/RegisterForm';
 
 export default function RegisterPage() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <RegisterPageContent />
+    <Suspense fallback={<div className="flex min-h-[70vh] items-center justify-center">Cargando…</div>}>
+      <RegisterForm />
     </Suspense>
   );
 }

--- a/app/servicios/ServiceCard.tsx
+++ b/app/servicios/ServiceCard.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useCartStore } from '@/lib/cart/store';
@@ -7,12 +8,30 @@ type Props = {
   id: string;
   name: string;
   description: string | null;
-  price: string;
+  priceCents: number | null;
+  currency: string | null;
 };
 
-export function ServiceCard({ id, name, description, price }: Props) {
+function formatPrice(priceCents: number | null, currency: string | null) {
+  if (priceCents === null) return 'Sin precio';
+  const formatter = new Intl.NumberFormat('es-ES', {
+    style: 'currency',
+    currency: currency || 'USD',
+    minimumFractionDigits: 2,
+  });
+  return formatter.format(priceCents / 100);
+}
+
+export function ServiceCard({ id, name, description, priceCents, currency }: Props) {
   const { addItem } = useCartStore();
-  const priceNumber = parseFloat(price.replace('$', ''));
+  const formattedPrice = formatPrice(priceCents, currency);
+  const isPurchasable = priceCents !== null;
+
+  const handleAddToCart = () => {
+    if (!isPurchasable) return;
+    addItem({ id, name, price: priceCents / 100, qty: 1 });
+  };
+
   return (
     <Card className="flex flex-col">
       <CardHeader>
@@ -21,15 +40,15 @@ export function ServiceCard({ id, name, description, price }: Props) {
       <CardContent className="flex flex-1 flex-col justify-between space-y-4">
         {description && (
           <ul className="list-disc space-y-1 pl-4 text-sm text-muted-foreground">
-            {description.split('\n').map((b) => (
-              <li key={b}>{b}</li>
+            {description.split('\n').map((bullet) => (
+              <li key={bullet}>{bullet}</li>
             ))}
           </ul>
         )}
         <div className="mt-auto space-y-2">
-          <p className="text-lg font-semibold">{price}</p>
-          <Button className="w-full" onClick={() => addItem({ id, name, price: priceNumber, qty: 1 })}>
-            Agregar al carrito
+          <p className="text-lg font-semibold">{formattedPrice}</p>
+          <Button className="w-full" onClick={handleAddToCart} disabled={!isPurchasable}>
+            {isPurchasable ? 'Agregar al carrito' : 'Consultar disponibilidad'}
           </Button>
         </div>
       </CardContent>

--- a/app/servicios/page.tsx
+++ b/app/servicios/page.tsx
@@ -6,27 +6,28 @@ export const revalidate = 0;
 export default async function ServiciosPage() {
   const servicios = await prisma.service.findMany({
     where: { isActive: true },
-    include: { prices: { where: { isCurrent: true }, take: 1 } },
-    orderBy: { name: 'asc' }
+    include: { prices: { where: { isCurrent: true }, take: 1, orderBy: { activeFrom: 'desc' } } },
+    orderBy: { name: 'asc' },
   });
 
   return (
     <div className="container py-8">
       <h1 className="mb-6 text-3xl font-bold">Servicios</h1>
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {servicios.map((s) => {
-          const p = s.prices[0];
-          const price = p ? `$${(p.amountCents / 100).toFixed(2)}` : 'Sin precio';
+        {servicios.map((service) => {
+          const price = service.prices[0] || null;
           return (
             <ServiceCard
-              key={s.id}
-              id={s.id}
-              name={s.name}
-              description={s.description}
-              price={price}
+              key={service.id}
+              id={service.id}
+              name={service.name}
+              description={service.description}
+              priceCents={price ? price.amountCents : null}
+              currency={price ? price.currency : null}
             />
           );
         })}
+        {servicios.length === 0 && <p>No hay servicios disponibles en este momento.</p>}
       </div>
     </div>
   );

--- a/components/Pricing.tsx
+++ b/components/Pricing.tsx
@@ -1,60 +1,39 @@
-'use client';
+import { prisma } from '@/lib/db';
+import { unstable_noStore as noStore } from 'next/cache';
+import { PricingGrid, PricingService } from '@/components/PricingGrid';
 
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { useRouter } from 'next/navigation';
-import { useCartStore } from '@/lib/cart/store';
-
-const plans = [
-  { name: 'Starter', price: 'Gratis', features: ['1 servicio'] },
-  {
-    name: 'Business',
-    price: 'USD 49',
-    features: ['Todo Starter', 'Soporte prioritario'],
-  },
-  {
-    name: 'Pro',
-    price: 'USD 99',
-    features: ['Todo Business', 'Integraciones avanzadas'],
-  },
-];
-
-export function Pricing() {
-  const router = useRouter();
-  const addItem = useCartStore((s) => s.addItem);
-
-  const handleAdd = (p: { name: string; price: string }) => {
-    const price = p.price.includes('USD')
-      ? parseFloat(p.price.replace('USD', '').trim())
-      : 0;
-    addItem({ id: p.name, name: p.name, price, qty: 1 });
-    router.push('/carrito');
-  };
+export async function Pricing() {
+  noStore();
+  let services: PricingService[] = [];
+  try {
+    const data = await prisma.service.findMany({
+      where: { isActive: true },
+      include: {
+        prices: { where: { isCurrent: true }, take: 1, orderBy: { activeFrom: 'desc' } },
+      },
+      orderBy: { name: 'asc' },
+    });
+    services = data.map((service) => {
+      const price = service.prices[0] || null;
+      return {
+        id: service.id,
+        name: service.name,
+        description: service.description,
+        priceCents: price ? price.amountCents : null,
+        currency: price ? price.currency : null,
+      };
+    });
+  } catch (error) {
+    services = [];
+  }
 
   return (
-    <section id="precios" className="mx-auto max-w-7xl px-4 pt-[var(--section-pt)] pb-[var(--section-pb)]">
+    <section
+      id="precios"
+      className="mx-auto max-w-7xl px-4 pt-[var(--section-pt)] pb-[var(--section-pb)]"
+    >
       <h2 className="mb-12 text-center text-3xl font-serif">Precios</h2>
-      <div className="grid gap-8 md:grid-cols-3">
-        {plans.map((p) => (
-          <Card key={p.name} className="text-center">
-            <CardHeader>
-              <CardTitle>{p.name}</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <p className="text-4xl font-bold">{p.price}</p>
-              <ul className="space-y-1 text-sm">
-                {p.features.map((f) => (
-                  <li key={f}>{f}</li>
-                ))}
-              </ul>
-              <Button onClick={() => handleAdd(p)} className="mt-4">
-                Agregar al carrito
-              </Button>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+      <PricingGrid services={services} />
     </section>
   );
 }
-

--- a/components/PricingGrid.tsx
+++ b/components/PricingGrid.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useCartStore } from '@/lib/cart/store';
+
+export type PricingService = {
+  id: string;
+  name: string;
+  description: string | null;
+  priceCents: number | null;
+  currency: string | null;
+};
+
+function formatPrice(priceCents: number | null, currency: string | null) {
+  if (priceCents === null) return 'Sin precio';
+  return new Intl.NumberFormat('es-ES', {
+    style: 'currency',
+    currency: currency || 'USD',
+    minimumFractionDigits: 2,
+  }).format(priceCents / 100);
+}
+
+export function PricingGrid({ services }: { services: PricingService[] }) {
+  const addItem = useCartStore((state) => state.addItem);
+
+  const handleAdd = (service: PricingService) => {
+    if (service.priceCents === null) return;
+    addItem({ id: service.id, name: service.name, price: service.priceCents / 100, qty: 1 });
+  };
+
+  if (services.length === 0) {
+    return <p className="text-center text-sm text-muted-foreground">Aún no hay productos disponibles.</p>;
+  }
+
+  return (
+    <div className="grid gap-8 md:grid-cols-3">
+      {services.map((service) => {
+        const formattedPrice = formatPrice(service.priceCents, service.currency);
+        const isPurchasable = service.priceCents !== null;
+        return (
+          <Card key={service.id} className="text-center">
+            <CardHeader>
+              <CardTitle>{service.name}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-4xl font-bold">{formattedPrice}</p>
+              {service.description && (
+                <ul className="space-y-1 text-sm">
+                  {service.description.split('\n').map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              )}
+              <Button
+                onClick={() => handleAdd(service)}
+                className="mt-4"
+                disabled={!isPurchasable}
+              >
+                {isPurchasable ? 'Agregar al carrito' : 'Consultar'}
+              </Button>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { FormEvent, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { signIn } from 'next-auth/react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+function buildRegisterUrl(email: string, next: string) {
+  const params = new URLSearchParams();
+  if (email) params.set('email', email);
+  params.set('welcome', '1');
+  params.set('next', next);
+  return `/register?${params.toString()}`;
+}
+
+export function LoginForm() {
+  const router = useRouter();
+  const search = useSearchParams();
+  const next = search.get('next') || '/servicios';
+  const [email, setEmail] = useState(() => search.get('email') || '');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    const queryEmail = search.get('email');
+    if (queryEmail) {
+      setEmail(queryEmail);
+    }
+  }, [search]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    if (!email || !password) {
+      setError('Ingresa tu email y contraseña.');
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const checkRes = await fetch(`/api/auth/check-email?email=${encodeURIComponent(email)}`, {
+        method: 'GET',
+        cache: 'no-store',
+      });
+      if (checkRes.ok) {
+        const data = (await checkRes.json()) as { exists: boolean };
+        if (!data.exists) {
+          setIsSubmitting(false);
+          router.push(buildRegisterUrl(email, next));
+          return;
+        }
+      }
+      const result = await signIn('credentials', {
+        email,
+        password,
+        redirect: false,
+        callbackUrl: next,
+      });
+      if (result?.ok) {
+        router.push(next);
+      } else if (result?.error === 'USER_NOT_FOUND') {
+        router.push(buildRegisterUrl(email, next));
+      } else {
+        setError('Credenciales inválidas. Intenta de nuevo.');
+      }
+    } catch (err) {
+      setError('No se pudo iniciar sesión. Intenta nuevamente.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-[70vh] items-center justify-center px-4 py-12">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md space-y-6 rounded-lg border border-border bg-background p-8 shadow-sm"
+      >
+        <div className="space-y-2 text-center">
+          <h1 className="text-2xl font-semibold">Iniciar sesión</h1>
+          <p className="text-sm text-muted-foreground">Accede con tus credenciales para continuar.</p>
+        </div>
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <label className="text-sm font-medium" htmlFor="email">
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="tucorreo@ejemplo.com"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium" htmlFor="password">
+              Contraseña
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="••••••••"
+            />
+          </div>
+        </div>
+        {error && (
+          <p className="text-sm text-red-500" role="alert">
+            {error}
+          </p>
+        )}
+        <button
+          type="submit"
+          className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Ingresando…' : 'Entrar'}
+        </button>
+        <p className="text-center text-sm text-muted-foreground">
+          ¿No tienes cuenta?{' '}
+          <Link href={buildRegisterUrl(email, next)} className="font-medium text-primary hover:underline">
+            Regístrate gratis
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { FormEvent, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { signIn } from 'next-auth/react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export function RegisterForm() {
+  const router = useRouter();
+  const search = useSearchParams();
+  const next = search.get('next') || '/servicios';
+  const welcome = search.get('welcome') === '1';
+  const [email, setEmail] = useState(() => search.get('email') || '');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    const queryEmail = search.get('email');
+    if (queryEmail) {
+      setEmail(queryEmail);
+    }
+  }, [search]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    if (!email || !password) {
+      setError('Completa todos los campos.');
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const response = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({ error: 'Error al registrarse' }));
+        setError(data.error || 'Error al registrarse');
+        return;
+      }
+      const signInResult = await signIn('credentials', {
+        email,
+        password,
+        redirect: false,
+        callbackUrl: next,
+      });
+      if (signInResult?.ok) {
+        router.push(next);
+      } else {
+        router.push('/login');
+      }
+    } catch (err) {
+      setError('No se pudo completar el registro. Intenta nuevamente.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-[70vh] items-center justify-center px-4 py-12">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-md space-y-6 rounded-lg border border-border bg-background p-8 shadow-sm"
+      >
+        <div className="space-y-2 text-center">
+          <h1 className="text-2xl font-semibold">Crea tu cuenta</h1>
+          <p className="text-sm text-muted-foreground">
+            {welcome ? '¡Bienvenido! Completa tus datos para comenzar.' : 'Regístrate para explorar nuestros cursos y servicios.'}
+          </p>
+        </div>
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <label className="text-sm font-medium" htmlFor="email">
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="tucorreo@ejemplo.com"
+            />
+          </div>
+          <div className="space-y-1">
+            <label className="text-sm font-medium" htmlFor="password">
+              Contraseña
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="new-password"
+              required
+              minLength={6}
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="Mínimo 6 caracteres"
+            />
+          </div>
+        </div>
+        {error && (
+          <p className="text-sm text-red-500" role="alert">
+            {error}
+          </p>
+        )}
+        <button
+          type="submit"
+          className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? 'Creando cuenta…' : 'Registrarme'}
+        </button>
+        <p className="text-center text-sm text-muted-foreground">
+          ¿Ya tienes una cuenta?{' '}
+          <Link href="/login" className="font-medium text-primary hover:underline">
+            Inicia sesión
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,7 +10,7 @@ export async function middleware(req: NextRequest) {
   const token = await getToken({ req, secret: env.NEXTAUTH_SECRET });
   const role = (token as any)?.role;
   if (!token || !['ADMIN', 'STAFF'].includes(role)) {
-    return NextResponse.redirect(new URL('/auth/login', req.url));
+    return NextResponse.redirect(new URL('/login', req.url));
   }
   return NextResponse.next();
 }

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -2,6 +2,6 @@ import { test, expect } from '@playwright/test';
 
 test('login page renders', async ({ page }) => {
   const baseUrl = process.env.PUBLIC_BASE_URL!;
-  await page.goto(`${baseUrl}/auth/login`);
+  await page.goto(`${baseUrl}/login`);
   await expect(page.locator('body')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- add an API endpoint and shared login/register client components to guide unregistered users into the welcome signup flow
- refresh login and register routes to reuse the new forms, redirect to the service catalog, and update middleware/tests to target `/login`
- render service pricing dynamically from admin-managed data with add-to-cart support on both the catalog and marketing pricing section

## Testing
- npm run lint *(fails: ESLint 9 from the environment cannot find the repo's Next.js configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d49186246483288c62974301fb886f