### PR TITLE
Fix admin login redirect flow

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth/next';
 import { redirect } from 'next/navigation';
 import type { Session } from 'next-auth';
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import { authOptions } from '@/lib/auth';
 import { AdminShell } from '@/components/admin/AdminShell';
 import { Playfair_Display, Inter } from 'next/font/google';
@@ -18,7 +19,11 @@ export const metadata: Metadata = {
 export default async function AdminLayout({ children }: { children: ReactNode }) {
   const session = (await getServerSession(authOptions)) as Session | null;
   if (!session || session.user.role !== 'ADMIN') {
-    redirect('/login');
+    const headersList = headers();
+    const invokePath = headersList.get('x-invoke-path');
+    const invokeQuery = headersList.get('x-invoke-query');
+    const pathWithQuery = invokePath ? `${invokePath}${invokeQuery ? `?${invokeQuery}` : ''}` : '/admin';
+    redirect(`/login?next=${encodeURIComponent(pathWithQuery)}`);
   }
   return (
     <div className={`${playfair.variable} ${inter.variable}`}>

--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -7,7 +7,7 @@ import { authOptions } from '@/lib/auth';
 export default async function CheckoutPage() {
   const session = await getServerSession(authOptions);
   if (!session) {
-    redirect('/login?redirect=/checkout');
+    redirect('/login?next=/checkout');
   }
   return (
     <Suspense fallback={null}>

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -16,7 +16,8 @@ function buildRegisterUrl(email: string, next: string) {
 export function LoginForm() {
   const router = useRouter();
   const search = useSearchParams();
-  const next = search.get('next') || '/servicios';
+  const nextParam = search.get('next') ?? search.get('redirect');
+  const next = nextParam && nextParam.startsWith('/') ? nextParam : '/servicios';
   const [email, setEmail] = useState(() => search.get('email') || '');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);

--- a/middleware.ts
+++ b/middleware.ts
@@ -10,7 +10,11 @@ export async function middleware(req: NextRequest) {
   const token = await getToken({ req, secret: env.NEXTAUTH_SECRET });
   const role = (token as any)?.role;
   if (!token || !['ADMIN', 'STAFF'].includes(role)) {
-    return NextResponse.redirect(new URL('/login', req.url));
+    const loginUrl = req.nextUrl.clone();
+    loginUrl.pathname = '/login';
+    const callbackPath = `${req.nextUrl.pathname}${req.nextUrl.search}`;
+    loginUrl.searchParams.set('next', callbackPath);
+    return NextResponse.redirect(loginUrl);
   }
   return NextResponse.next();
 }


### PR DESCRIPTION
## Summary
- preserve the requested admin path when redirecting unauthenticated users to the login page
- ensure the login form respects both `next` and legacy `redirect` parameters and sanitize the callback path
- align checkout's guard with the unified `next` parameter so post-login navigation returns to the checkout flow

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d4966ee9cc8328b1ad6dfec3a812d0